### PR TITLE
fix: update dart commads

### DIFF
--- a/src/Detector/Adapter/Dart.php
+++ b/src/Detector/Adapter/Dart.php
@@ -37,12 +37,12 @@ class Dart extends Adapter
 
     public function getInstallCommand(): string
     {
-        return 'flutter pub get';
+        return 'dart pub get';
     }
 
     public function getBuildCommand(): string
     {
-        return 'flutter build';
+        return 'dart build';
     }
 
     public function getEntryPoint(): string


### PR DESCRIPTION
The dart install and build commands were using the `flutter` command which is a client side command unavailable in dart server side environments