### PR TITLE
Fix: Unahtorized clone

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,4 +27,4 @@ jobs:
 
     - name: Run Tests
       run: |
-        docker-compose exec -T tests vendor/bin/phpunit --configuration phpunit.xml tests
+        docker compose exec -T tests vendor/bin/phpunit --configuration phpunit.xml tests

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -516,8 +516,9 @@ class GitHub extends Git
         // URL encode the components for the clone URL
         $owner = urlencode($owner);
         $repositoryName = urlencode($repositoryName);
-        $accessToken = urlencode($this->accessToken);
-        $cloneUrl = "https://{$owner}:{$accessToken}@github.com/{$owner}/{$repositoryName}";
+        $accessToken = !empty($this->accessToken) ? ':' . urlencode($this->accessToken) : '';
+
+        $cloneUrl = "https://{$owner}{$accessToken}@github.com/{$owner}/{$repositoryName}";
 
         $directory = escapeshellarg($directory);
         $rootDirectory = escapeshellarg($rootDirectory);


### PR DESCRIPTION
Allow clone command generation without access token. This works great when repository is public and there is no installation