### PR TITLE
Check value of deleted on push

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -586,6 +586,7 @@ class GitHub extends Git
         switch ($event) {
             case 'push':
                 $branchCreated = isset($payload['created']) ? $payload['created'] : false;
+                $branchDeleted = isset($payload['deleted']) ? $payload['deleted'] : false;
                 $ref = $payload['ref'] ?? '';
                 $repositoryId = strval($payload['repository']['id'] ?? '');
                 $repositoryName = $payload['repository']['name'] ?? '';
@@ -602,6 +603,7 @@ class GitHub extends Git
 
                 return [
                     'branchCreated' => $branchCreated,
+                    'branchDeleted' => $branchDeleted,
                     'branch' => $branch,
                     'branchUrl' => $branchUrl,
                     'repositoryId' => $repositoryId,


### PR DESCRIPTION
On `push` events, capture value of `deleted` attribute

<img width="560" alt="Screenshot 2025-06-02 at 1 36 04 PM" src="https://github.com/user-attachments/assets/cae754fc-4739-4854-8372-0dede1fe4e2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Push event details now include information about branch deletions, allowing users to see when a branch has been deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->