### PR TITLE
Use html_url in push events

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -591,8 +591,8 @@ class GitHub extends Git
                 $repositoryId = strval($payload['repository']['id'] ?? '');
                 $repositoryName = $payload['repository']['name'] ?? '';
                 $branch = str_replace('refs/heads/', '', $ref);
-                $branchUrl = $payload['repository']['url'] . "/tree/" . $branch;
-                $repositoryUrl = $payload['repository']['url'];
+                $branchUrl = $payload['repository']['html_url'] . "/tree/" . $branch;
+                $repositoryUrl = $payload['repository']['html_url'];
                 $commitHash = $payload['after'] ?? '';
                 $owner = $payload['repository']['owner']['name'] ?? '';
                 $authorUrl = $payload['sender']['html_url'];


### PR DESCRIPTION
`url` starts with `api.github.com` whereas `html_url` starts with `github.com..`