### PR TITLE
Set author email when parsing push events

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -601,7 +601,7 @@ class GitHub extends Git
                 $owner = $payload['repository']['owner']['name'] ?? '';
                 $authorUrl = $payload['sender']['html_url'];
                 $authorAvatarUrl = $payload['sender']['avatar_url'] ?? '';
-                $headCommitAuthor = $payload['head_commit']['author']['name'] ?? '';
+                $headCommitAuthorName = $payload['head_commit']['author']['name'] ?? '';
                 $headCommitAuthorEmail = $payload['head_commit']['author']['email'] ?? '';
                 $headCommitMessage = $payload['head_commit']['message'] ?? '';
                 $headCommitUrl = $payload['head_commit']['url'] ?? '';
@@ -619,7 +619,7 @@ class GitHub extends Git
                     'owner' => $owner,
                     'authorUrl' => $authorUrl,
                     'authorAvatarUrl' => $authorAvatarUrl,
-                    'headCommitAuthor' => $headCommitAuthor,
+                    'headCommitAuthorName' => $headCommitAuthorName,
                     'headCommitAuthorEmail' => $headCommitAuthorEmail,
                     'headCommitMessage' => $headCommitMessage,
                     'headCommitUrl' => $headCommitUrl,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The commit author's email address is now extracted and made available for GitHub push events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->