### PR TITLE
fix: Check org membership to determine external PR

### DIFF
--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -252,6 +252,8 @@ abstract class Adapter
      */
     abstract public function getLatestCommit(string $owner, string $repositoryName, string $branch): array;
 
+    abstract public function isUserMemberOfOrganization(string $username, string $organization): bool;
+
     /**
      * Call
      *

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -640,7 +640,13 @@ class GitHub extends Git
                 $authorAvatarUrl = $payload['pull_request']['user']['avatar_url'] ?? '';
                 $commitHash = $payload['pull_request']['head']['sha'] ?? '';
                 $headCommitUrl = $repositoryUrl . "/commits/" . $commitHash;
-                $external = $payload['pull_request']['head']['user']['login'] !== $payload['pull_request']['base']['user']['login'];
+
+                $isOrgRepository = ($payload['repository']['owner']['type'] ?? '') === 'Organization';
+                if ($isOrgRepository) {
+                    $external = !$this->isUserMemberOfOrganization($owner, $owner);
+                } else {
+                    $external = $payload['pull_request']['head']['user']['login'] !== $payload['repository']['owner']['login'];
+                }
 
                 return [
                     'branch' => $branch,
@@ -685,5 +691,12 @@ class GitHub extends Git
     public function validateWebhookEvent(string $payload, string $signature, string $signatureKey): bool
     {
         return $signature === ('sha256=' . hash_hmac('sha256', $payload, $signatureKey));
+    }
+
+    public function isUserMemberOfOrganization(string $username, string $organization): bool
+    {
+        $url = "/orgs/{$organization}/memberships/{$username}";
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "Bearer $this->accessToken"]);
+        return $response['headers']['status-code'] >= 200 && $response['headers']['status-code'] < 300;
     }
 }

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -340,4 +340,13 @@ class GitHubTest extends Base
         $this->assertEquals('https://avatars.githubusercontent.com/u/43381712?v=4', $commitDetails['commitAuthorAvatar']);
         $this->assertEquals('https://github.com/vermakhushboo', $commitDetails['commitAuthorUrl']);
     }
+
+    public function testIsUserMemberOfOrganization(): void
+    {
+        $isMember = $this->vcsAdapter->isUserMemberOfOrganization('hmacr', 'test-org-hmacr');
+        $this->assertTrue($isMember);
+
+        $isNotMember = $this->vcsAdapter->isUserMemberOfOrganization('test-user', 'test-org-hmacr');
+        $this->assertFalse($isNotMember);
+    }
 }


### PR DESCRIPTION
Noticed that we don't check org membership when determining external pull request contributions.

Related task: https://linear.app/appwrite/issue/SER-355/fix-external-vcs-deployments