### PR TITLE
fix: disable sparse checkout cone mode to prevent root file leaks

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -857,21 +857,30 @@ class GitHub extends Git
         $directory = escapeshellarg($directory);
         $rootDirectory = escapeshellarg($rootDirectory);
 
+        $isSubdirectory = $rootDirectory !== escapeshellarg('*');
+
         $commands = [
             "mkdir -p {$directory}",
             "cd {$directory}",
             "git config --global init.defaultBranch main",
             "git init",
             "git remote add origin {$cloneUrl}",
-            // Enable non-cone sparse checkout (cone mode includes root-level files)
+            // Enable sparse checkout
             "git config core.sparseCheckout true",
-            "git config core.sparseCheckoutCone false",
+        ];
+
+        // Disable cone mode for subdirectory checkouts (cone mode includes root-level files)
+        if ($isSubdirectory) {
+            $commands[] = "git config core.sparseCheckoutCone false";
+        }
+
+        $commands = array_merge($commands, [
             "echo {$rootDirectory} >> .git/info/sparse-checkout",
             // Disable fetching of refs we don't need
             "git config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",
             // Disable fetching of tags
             "git config remote.origin.tagopt --no-tags",
-        ];
+        ]);
 
         switch ($versionType) {
             case self::CLONE_TYPE_BRANCH:

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -863,8 +863,9 @@ class GitHub extends Git
             "git config --global init.defaultBranch main",
             "git init",
             "git remote add origin {$cloneUrl}",
-            // Enable sparse checkout
+            // Enable non-cone sparse checkout (cone mode includes root-level files)
             "git config core.sparseCheckout true",
+            "git config core.sparseCheckoutCone false",
             "echo {$rootDirectory} >> .git/info/sparse-checkout",
             // Disable fetching of refs we don't need
             "git config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",


### PR DESCRIPTION
## Summary
- Git 2.37+ defaults to cone mode for sparse checkout, which always includes root-level files alongside the specified subdirectory
- This causes VCS function deployments with a non-root `providerRootDirectory` to include root-level files (e.g. `build.gradle.kts`, `package.json`) that can break function builds
- Affected since Appwrite 1.5.0 (ships Git 2.43.0), including Cloud (1.9.0 ships Git 2.52.0)
- Fix: set `core.sparseCheckoutCone false` before writing the sparse-checkout pattern

## Test plan
- [ ] Existing `testGenerateCloneCommand*` tests pass (pattern `*` clones everything regardless of cone mode)
- [ ] VCS deployment with nested `providerRootDirectory` no longer includes root-level files