### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -408,7 +408,6 @@ abstract class Adapter
             throw new Exception(curl_error($ch) . ' with status code ' . $responseStatus, $responseStatus);
         }
 
-
         $responseHeaders['status-code'] = $responseStatus;
 
         if ($responseStatus === 500) {

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -408,7 +408,6 @@ abstract class Adapter
             throw new Exception(curl_error($ch) . ' with status code ' . $responseStatus, $responseStatus);
         }
 
-        curl_close($ch);
 
         $responseHeaders['status-code'] = $responseStatus;
 


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
