### PR TITLE
chore: allow utopia-php/cache 2.0.* alongside 1.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=8.0",
     "adhocore/jwt": "^1.1",
-    "utopia-php/cache": "1.0.*",
+    "utopia-php/cache": "1.0.* || 2.0.*",
     "utopia-php/fetch": "^1.1"
   },
   "require-dev": {


### PR DESCRIPTION
## What

Widen the `utopia-php/cache` constraint from `1.0.*` to `1.0.* || 2.0.*`.

## Why

`utopia-php/cache` 2.0.0 was released ([release notes](https://github.com/utopia-php/cache/releases/tag/2.0.0)). It bumps the PHP floor to `>=8.2`, adds a `CircuitBreaker` adapter and a `Feature\Telemetry` propagation contract — all additive. The `Utopia\Cache\Cache` type used in the Git adapters here is unchanged.

This package's PHP floor remains `>=8.0`; allowing both `1.0.*` and `2.0.*` lets Composer pick cache 1.x on PHP 8.0/8.1 and cache 2.x on PHP 8.2+. Downstream consumers (e.g. appwrite/appwrite, which is on PHP 8.4+) can then pick up cache 2.0.

## Test plan

- [ ] CI passes against both cache 1.0.x and 2.0.x