### PR TITLE
chore: bump utopia-php/cache to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=8.2",
     "adhocore/jwt": "^1.1",
-    "utopia-php/cache": "^2.0",
+    "utopia-php/cache": "^3.0",
     "utopia-php/fetch": "^1.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b37b7bff901c1c81b99777291b45b7",
+    "content-hash": "d192c64708d6e41b23e3a500b6490574",
     "packages": [
         {
             "name": "adhocore/jwt",
@@ -1938,23 +1938,23 @@
         },
         {
             "name": "utopia-php/cache",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cache.git",
-                "reference": "ef1d122a464b3469f2a11c7d751214e72b76eee0"
+                "reference": "ece1f4d11ec2804cd7e05b9717dc7a2bc66e4176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cache/zipball/ef1d122a464b3469f2a11c7d751214e72b76eee0",
-                "reference": "ef1d122a464b3469f2a11c7d751214e72b76eee0",
+                "url": "https://api.github.com/repos/utopia-php/cache/zipball/ece1f4d11ec2804cd7e05b9717dc7a2bc66e4176",
+                "reference": "ece1f4d11ec2804cd7e05b9717dc7a2bc66e4176",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-memcached": "*",
                 "ext-redis": "*",
-                "php": ">=8.2",
+                "php": ">=8.3",
                 "utopia-php/circuit-breaker": "0.3.*",
                 "utopia-php/pools": "1.*",
                 "utopia-php/telemetry": "*"
@@ -1963,6 +1963,7 @@
                 "laravel/pint": "1.2.*",
                 "phpstan/phpstan": "^1.12",
                 "phpunit/phpunit": "^9.3",
+                "swoole/ide-helper": "^6.0",
                 "vimeo/psalm": "4.13.1"
             },
             "type": "library",
@@ -1985,9 +1986,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cache/issues",
-                "source": "https://github.com/utopia-php/cache/tree/2.0.0"
+                "source": "https://github.com/utopia-php/cache/tree/3.0.0"
             },
-            "time": "2026-05-12T10:55:15+00:00"
+            "time": "2026-05-14T14:13:17+00:00"
         },
         {
             "name": "utopia-php/circuit-breaker",


### PR DESCRIPTION
## Summary
- Bump `utopia-php/cache` constraint from `^2.0` to `^3.0`.

## Breaking changes review
The 3.0 release ([PR #71](https://github.com/utopia-php/cache/pull/71)) extracted retry methods (`setMaxRetries`, `setRetryDelay`, `getMaxRetries`, `getRetryDelay`) and the `MIN_RETRIES`/`MAX_RETRIES` constants off the base `Adapter` interface into a new `Feature\Retryable` interface. This repo only calls `Cache::load()` and `Cache::save()` (in `src/VCS/Adapter/Git/GitHub.php`), whose signatures are unchanged — so no code changes are required.

## Test plan
- [ ] `composer install`
- [ ] `composer test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)