### PR TITLE
feat: add createCheckRun for Check Runs API

### DIFF
--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -236,12 +236,38 @@ abstract class Adapter
     abstract public function updateCommitStatus(string $repositoryName, string $SHA, string $owner, string $state, string $description = '', string $target_url = '', string $context = ''): void;
 
     /**
-     * Creates a completed check run for a commit.
-     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     * Creates a check run for a commit.
+     * status can be one of: queued, in_progress, completed
+     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     *
+     * @return array<mixed>
      */
-    public function createCheckRun(string $owner, string $repositoryName, string $headSha, string $name, string $conclusion, string $title, string $summary): void
-    {
+    public function createCheckRun(
+        string $owner,
+        string $repositoryName,
+        string $headSha,
+        string $name,
+        string $status = 'queued',
+        string $conclusion = '',
+        string $title = '',
+        string $summary = '',
+        string $text = '',
+        string $detailsUrl = '',
+        string $externalId = '',
+        string $startedAt = '',
+        string $completedAt = '',
+    ): array {
         throw new \Exception('createCheckRun() is not implemented for ' . $this->getName());
+    }
+
+    /**
+     * Gets a check run by ID.
+     *
+     * @return array<mixed>
+     */
+    public function getCheckRun(string $owner, string $repositoryName, int $checkRunId): array
+    {
+        throw new \Exception('getCheckRun() is not implemented for ' . $this->getName());
     }
 
     /**

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -275,6 +275,35 @@ abstract class Adapter
     }
 
     /**
+     * Updates an existing check run.
+     * status can be one of: queued, in_progress, completed
+     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     *
+     * @param array<mixed> $annotations
+     * @param array<mixed> $images
+     * @return array<mixed>
+     */
+    public function updateCheckRun(
+        string $owner,
+        string $repositoryName,
+        int $checkRunId,
+        string $name = '',
+        string $status = '',
+        string $conclusion = '',
+        string $title = '',
+        string $summary = '',
+        string $text = '',
+        array $annotations = [],
+        array $images = [],
+        string $detailsUrl = '',
+        string $externalId = '',
+        string $startedAt = '',
+        string $completedAt = '',
+    ): array {
+        throw new \Exception('updateCheckRun() is not implemented for ' . $this->getName());
+    }
+
+    /**
      * Get repository tree
      *
      * @param string $owner Owner name of the repository

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -240,6 +240,8 @@ abstract class Adapter
      * status can be one of: queued, in_progress, completed
      * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
      *
+     * @param array<mixed> $annotations
+     * @param array<mixed> $images
      * @return array<mixed>
      */
     public function createCheckRun(
@@ -252,6 +254,8 @@ abstract class Adapter
         string $title = '',
         string $summary = '',
         string $text = '',
+        array $annotations = [],
+        array $images = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -236,6 +236,15 @@ abstract class Adapter
     abstract public function updateCommitStatus(string $repositoryName, string $SHA, string $owner, string $state, string $description = '', string $target_url = '', string $context = ''): void;
 
     /**
+     * Creates a completed check run for a commit.
+     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     */
+    public function createCheckRun(string $owner, string $repositoryName, string $headSha, string $name, string $conclusion, string $title, string $summary): void
+    {
+        throw new \Exception('createCheckRun() is not implemented for ' . $this->getName());
+    }
+
+    /**
      * Get repository tree
      *
      * @param string $owner Owner name of the repository

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -237,11 +237,12 @@ abstract class Adapter
 
     /**
      * Creates a check run for a commit.
-     * status can be one of: queued, in_progress, completed
-     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     * status can be one of: queued, in_progress
+     * Use updateCheckRun() to set conclusion and mark the run as completed.
      *
      * @param array<mixed> $annotations
      * @param array<mixed> $images
+     * @param array<mixed> $actions
      * @return array<mixed>
      */
     public function createCheckRun(
@@ -250,16 +251,15 @@ abstract class Adapter
         string $headSha,
         string $name,
         string $status = 'queued',
-        string $conclusion = '',
         string $title = '',
         string $summary = '',
         string $text = '',
         array $annotations = [],
         array $images = [],
+        array $actions = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
-        string $completedAt = '',
     ): array {
         throw new \Exception('createCheckRun() is not implemented for ' . $this->getName());
     }
@@ -281,6 +281,7 @@ abstract class Adapter
      *
      * @param array<mixed> $annotations
      * @param array<mixed> $images
+     * @param array<mixed> $actions
      * @return array<mixed>
      */
     public function updateCheckRun(
@@ -295,6 +296,7 @@ abstract class Adapter
         string $text = '',
         array $annotations = [],
         array $images = [],
+        array $actions = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',

--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -251,6 +251,7 @@ abstract class Adapter
         string $headSha,
         string $name,
         string $status = 'queued',
+        string $conclusion = '',
         string $title = '',
         string $summary = '',
         string $text = '',
@@ -260,6 +261,7 @@ abstract class Adapter
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
+        string $completedAt = '',
     ): array {
         throw new \Exception('createCheckRun() is not implemented for ' . $this->getName());
     }

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -873,6 +873,28 @@ class GitHub extends Git
     }
 
     /**
+     * Creates a completed check run for a commit.
+     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, stale, timed_out
+     */
+    public function createCheckRun(string $owner, string $repositoryName, string $headSha, string $name, string $conclusion, string $title, string $summary): void
+    {
+        $url = "/repos/$owner/$repositoryName/check-runs";
+
+        $body = [
+            'name' => $name,
+            'head_sha' => $headSha,
+            'status' => 'completed',
+            'conclusion' => $conclusion,
+            'output' => [
+                'title' => $title,
+                'summary' => $summary,
+            ],
+        ];
+
+        $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
+    }
+
+    /**
      * Generates a clone command using app access token
      */
     public function generateCloneCommand(string $owner, string $repositoryName, string $version, string $versionType, string $directory, string $rootDirectory): string

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -1035,6 +1035,11 @@ class GitHub extends Git
 
         $response = $this->call(self::METHOD_PATCH, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
 
+        $responseHeadersStatusCode = $response['headers']['status-code'] ?? 0;
+        if ($responseHeadersStatusCode >= 400) {
+            throw new Exception("Failed to update check run $checkRunId: HTTP $responseHeadersStatusCode");
+        }
+
         return $response['body'] ?? [];
     }
 

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -874,8 +874,8 @@ class GitHub extends Git
 
     /**
      * Creates a check run for a commit.
-     * status can be one of: queued, in_progress
-     * Use updateCheckRun() to set conclusion and mark the run as completed.
+     * status can be one of: queued, in_progress, completed
+     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
      *
      * @param array<mixed> $annotations
      * @param array<mixed> $images
@@ -888,6 +888,7 @@ class GitHub extends Git
         string $headSha,
         string $name,
         string $status = 'queued',
+        string $conclusion = '',
         string $title = '',
         string $summary = '',
         string $text = '',
@@ -897,8 +898,17 @@ class GitHub extends Git
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
+        string $completedAt = '',
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
+
+        // Conclusion requires status=completed; auto-set completed_at if not provided.
+        if (!empty($conclusion)) {
+            $status = 'completed';
+            if (empty($completedAt)) {
+                $completedAt = gmdate('Y-m-d\TH:i:s\Z');
+            }
+        }
 
         $body = array_merge(
             [
@@ -907,6 +917,8 @@ class GitHub extends Git
                 'status' => $status,
             ],
             array_filter([
+                'conclusion' => $conclusion,
+                'completed_at' => $completedAt,
                 'details_url' => $detailsUrl,
                 'external_id' => $externalId,
                 'started_at' => $startedAt,

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -902,6 +902,10 @@ class GitHub extends Git
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
 
+        if ($status === 'completed' && empty($conclusion)) {
+            throw new Exception("conclusion is required when status is 'completed'");
+        }
+
         // Conclusion requires status=completed; auto-set completed_at if not provided.
         if (!empty($conclusion)) {
             $status = 'completed';
@@ -998,6 +1002,10 @@ class GitHub extends Git
         string $completedAt = '',
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs/$checkRunId";
+
+        if ($status === 'completed' && empty($conclusion)) {
+            throw new Exception("conclusion is required when status is 'completed'");
+        }
 
         // Conclusion requires status=completed; auto-set completed_at if not provided.
         if (!empty($conclusion)) {

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -879,6 +879,10 @@ class GitHub extends Git
      *
      * @return array<mixed>
      */
+    /**
+     * @param array<mixed> $annotations
+     * @param array<mixed> $images
+     */
     public function createCheckRun(
         string $owner,
         string $repositoryName,
@@ -889,6 +893,8 @@ class GitHub extends Git
         string $title = '',
         string $summary = '',
         string $text = '',
+        array $annotations = [],
+        array $images = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
@@ -912,11 +918,20 @@ class GitHub extends Git
         );
 
         if (!empty($title) || !empty($summary)) {
-            $body['output'] = array_filter([
+            $output = array_filter([
                 'title' => $title,
                 'summary' => $summary,
                 'text' => $text,
             ], fn ($value) => !empty($value));
+
+            if (!empty($annotations)) {
+                $output['annotations'] = $annotations;
+            }
+            if (!empty($images)) {
+                $output['images'] = $images;
+            }
+
+            $body['output'] = $output;
         }
 
         $response = $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -943,6 +943,11 @@ class GitHub extends Git
 
         $response = $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
 
+        $responseHeadersStatusCode = $response['headers']['status-code'] ?? 0;
+        if ($responseHeadersStatusCode >= 400) {
+            throw new Exception("Failed to create check run: HTTP $responseHeadersStatusCode");
+        }
+
         return $response['body'] ?? [];
     }
 
@@ -956,6 +961,11 @@ class GitHub extends Git
         $url = "/repos/$owner/$repositoryName/check-runs/$checkRunId";
 
         $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "Bearer $this->accessToken"]);
+
+        $responseHeadersStatusCode = $response['headers']['status-code'] ?? 0;
+        if ($responseHeadersStatusCode >= 400) {
+            throw new Exception("Failed to get check run $checkRunId: HTTP $responseHeadersStatusCode");
+        }
 
         return $response['body'] ?? [];
     }

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -954,6 +954,66 @@ class GitHub extends Git
     }
 
     /**
+     * Updates an existing check run.
+     * status can be one of: queued, in_progress, completed
+     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     *
+     * @param array<mixed> $annotations
+     * @param array<mixed> $images
+     * @return array<mixed>
+     */
+    public function updateCheckRun(
+        string $owner,
+        string $repositoryName,
+        int $checkRunId,
+        string $name = '',
+        string $status = '',
+        string $conclusion = '',
+        string $title = '',
+        string $summary = '',
+        string $text = '',
+        array $annotations = [],
+        array $images = [],
+        string $detailsUrl = '',
+        string $externalId = '',
+        string $startedAt = '',
+        string $completedAt = '',
+    ): array {
+        $url = "/repos/$owner/$repositoryName/check-runs/$checkRunId";
+
+        $body = array_filter([
+            'name' => $name,
+            'status' => $status,
+            'details_url' => $detailsUrl,
+            'external_id' => $externalId,
+            'started_at' => $startedAt,
+            'conclusion' => $conclusion,
+            'completed_at' => $completedAt,
+        ], fn ($value) => !empty($value));
+
+        if (!empty($title) || !empty($summary)) {
+            $output = array_filter([
+                'title' => $title,
+                'summary' => $summary,
+                'text' => $text,
+            ], fn ($value) => !empty($value));
+
+            if (!empty($annotations)) {
+                $output['annotations'] = $annotations;
+            }
+            if (!empty($images)) {
+                $output['images'] = $images;
+            }
+
+            $body['output'] = $output;
+        }
+
+        $response = $this->call(self::METHOD_PATCH, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
+
+        return $response['body'] ?? [];
+    }
+
+    /**
      * Generates a clone command using app access token
      */
     public function generateCloneCommand(string $owner, string $repositoryName, string $version, string $versionType, string $directory, string $rootDirectory): string

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -874,11 +874,12 @@ class GitHub extends Git
 
     /**
      * Creates a check run for a commit.
-     * status can be one of: queued, in_progress, completed
-     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     * status can be one of: queued, in_progress
+     * Use updateCheckRun() to set conclusion and mark the run as completed.
      *
      * @param array<mixed> $annotations
      * @param array<mixed> $images
+     * @param array<mixed> $actions
      * @return array<mixed>
      */
     public function createCheckRun(
@@ -887,26 +888,17 @@ class GitHub extends Git
         string $headSha,
         string $name,
         string $status = 'queued',
-        string $conclusion = '',
         string $title = '',
         string $summary = '',
         string $text = '',
         array $annotations = [],
         array $images = [],
+        array $actions = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
-        string $completedAt = '',
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
-
-        // Conclusion requires status=completed; auto-set completed_at if not provided.
-        if (!empty($conclusion)) {
-            $status = 'completed';
-            if (empty($completedAt)) {
-                $completedAt = gmdate('Y-m-d\TH:i:s\Z');
-            }
-        }
 
         $body = array_merge(
             [
@@ -918,8 +910,6 @@ class GitHub extends Git
                 'details_url' => $detailsUrl,
                 'external_id' => $externalId,
                 'started_at' => $startedAt,
-                'conclusion' => $conclusion,
-                'completed_at' => $completedAt,
             ], fn ($value) => !empty($value))
         );
 
@@ -933,6 +923,10 @@ class GitHub extends Git
                 $output['images'] = $images;
             }
             $body['output'] = $output;
+        }
+
+        if (!empty($actions)) {
+            $body['actions'] = $actions;
         }
 
         $response = $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
@@ -975,6 +969,7 @@ class GitHub extends Git
         string $text = '',
         array $annotations = [],
         array $images = [],
+        array $actions = [],
         string $detailsUrl = '',
         string $externalId = '',
         string $startedAt = '',
@@ -1010,6 +1005,10 @@ class GitHub extends Git
                 $output['images'] = $images;
             }
             $body['output'] = $output;
+        }
+
+        if (!empty($actions)) {
+            $body['actions'] = $actions;
         }
 
         $response = $this->call(self::METHOD_PATCH, $url, ['Authorization' => "Bearer $this->accessToken"], $body);

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -877,11 +877,9 @@ class GitHub extends Git
      * status can be one of: queued, in_progress, completed
      * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
      *
-     * @return array<mixed>
-     */
-    /**
      * @param array<mixed> $annotations
      * @param array<mixed> $images
+     * @return array<mixed>
      */
     public function createCheckRun(
         string $owner,
@@ -917,20 +915,8 @@ class GitHub extends Git
             ], fn ($value) => !empty($value))
         );
 
-        if (!empty($title) || !empty($summary)) {
-            $output = array_filter([
-                'title' => $title,
-                'summary' => $summary,
-                'text' => $text,
-            ], fn ($value) => !empty($value));
-
-            if (!empty($annotations)) {
-                $output['annotations'] = $annotations;
-            }
-            if (!empty($images)) {
-                $output['images'] = $images;
-            }
-
+        $output = $this->buildCheckRunOutput($title, $summary, $text, $annotations, $images);
+        if (!empty($output)) {
             $body['output'] = $output;
         }
 
@@ -991,26 +977,43 @@ class GitHub extends Git
             'completed_at' => $completedAt,
         ], fn ($value) => !empty($value));
 
-        if (!empty($title) || !empty($summary)) {
-            $output = array_filter([
-                'title' => $title,
-                'summary' => $summary,
-                'text' => $text,
-            ], fn ($value) => !empty($value));
-
-            if (!empty($annotations)) {
-                $output['annotations'] = $annotations;
-            }
-            if (!empty($images)) {
-                $output['images'] = $images;
-            }
-
+        $output = $this->buildCheckRunOutput($title, $summary, $text, $annotations, $images);
+        if (!empty($output)) {
             $body['output'] = $output;
         }
 
         $response = $this->call(self::METHOD_PATCH, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
 
         return $response['body'] ?? [];
+    }
+
+    /**
+     * Builds the output block for a check run.
+     *
+     * @param array<mixed> $annotations
+     * @param array<mixed> $images
+     * @return array<mixed>
+     */
+    private function buildCheckRunOutput(string $title, string $summary, string $text, array $annotations, array $images): array
+    {
+        if (empty($title) && empty($summary)) {
+            return [];
+        }
+
+        $output = array_filter([
+            'title' => $title,
+            'summary' => $summary,
+            'text' => $text,
+        ], fn ($value) => !empty($value));
+
+        if (!empty($annotations)) {
+            $output['annotations'] = $annotations;
+        }
+        if (!empty($images)) {
+            $output['images'] = $images;
+        }
+
+        return $output;
     }
 
     /**

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -915,8 +915,14 @@ class GitHub extends Git
             ], fn ($value) => !empty($value))
         );
 
-        $output = $this->buildCheckRunOutput($title, $summary, $text, $annotations, $images);
-        if (!empty($output)) {
+        if (!empty($title) || !empty($summary)) {
+            $output = array_filter(['title' => $title, 'summary' => $summary, 'text' => $text], fn ($value) => !empty($value));
+            if (!empty($annotations)) {
+                $output['annotations'] = $annotations;
+            }
+            if (!empty($images)) {
+                $output['images'] = $images;
+            }
             $body['output'] = $output;
         }
 
@@ -977,43 +983,20 @@ class GitHub extends Git
             'completed_at' => $completedAt,
         ], fn ($value) => !empty($value));
 
-        $output = $this->buildCheckRunOutput($title, $summary, $text, $annotations, $images);
-        if (!empty($output)) {
+        if (!empty($title) || !empty($summary)) {
+            $output = array_filter(['title' => $title, 'summary' => $summary, 'text' => $text], fn ($value) => !empty($value));
+            if (!empty($annotations)) {
+                $output['annotations'] = $annotations;
+            }
+            if (!empty($images)) {
+                $output['images'] = $images;
+            }
             $body['output'] = $output;
         }
 
         $response = $this->call(self::METHOD_PATCH, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
 
         return $response['body'] ?? [];
-    }
-
-    /**
-     * Builds the output block for a check run.
-     *
-     * @param array<mixed> $annotations
-     * @param array<mixed> $images
-     * @return array<mixed>
-     */
-    private function buildCheckRunOutput(string $title, string $summary, string $text, array $annotations, array $images): array
-    {
-        if (empty($title) && empty($summary)) {
-            return [];
-        }
-
-        $output = array_filter([
-            'title' => $title,
-            'summary' => $summary,
-            'text' => $text,
-        ], fn ($value) => !empty($value));
-
-        if (!empty($annotations)) {
-            $output['annotations'] = $annotations;
-        }
-        if (!empty($images)) {
-            $output['images'] = $images;
-        }
-
-        return $output;
     }
 
     /**

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -896,35 +896,27 @@ class GitHub extends Git
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
 
-        $body = [
-            'name' => $name,
-            'head_sha' => $headSha,
-            'status' => $status,
-        ];
+        $body = array_merge(
+            [
+                'name' => $name,
+                'head_sha' => $headSha,
+                'status' => $status,
+            ],
+            array_filter([
+                'details_url' => $detailsUrl,
+                'external_id' => $externalId,
+                'started_at' => $startedAt,
+                'conclusion' => $conclusion,
+                'completed_at' => $completedAt,
+            ], fn ($value) => !empty($value))
+        );
 
-        if (!empty($detailsUrl)) {
-            $body['details_url'] = $detailsUrl;
-        }
-        if (!empty($externalId)) {
-            $body['external_id'] = $externalId;
-        }
-        if (!empty($startedAt)) {
-            $body['started_at'] = $startedAt;
-        }
-        if (!empty($conclusion)) {
-            $body['conclusion'] = $conclusion;
-        }
-        if (!empty($completedAt)) {
-            $body['completed_at'] = $completedAt;
-        }
         if (!empty($title) || !empty($summary)) {
-            $body['output'] = [
+            $body['output'] = array_filter([
                 'title' => $title,
                 'summary' => $summary,
-            ];
-            if (!empty($text)) {
-                $body['output']['text'] = $text;
-            }
+                'text' => $text,
+            ], fn ($value) => !empty($value));
         }
 
         $response = $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -873,26 +873,77 @@ class GitHub extends Git
     }
 
     /**
-     * Creates a completed check run for a commit.
-     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     * Creates a check run for a commit.
+     * status can be one of: queued, in_progress, completed
+     * conclusion (required when status=completed) can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
+     *
+     * @return array<mixed>
      */
-    public function createCheckRun(string $owner, string $repositoryName, string $headSha, string $name, string $conclusion, string $title, string $summary): void
-    {
+    public function createCheckRun(
+        string $owner,
+        string $repositoryName,
+        string $headSha,
+        string $name,
+        string $status = 'queued',
+        string $conclusion = '',
+        string $title = '',
+        string $summary = '',
+        string $text = '',
+        string $detailsUrl = '',
+        string $externalId = '',
+        string $startedAt = '',
+        string $completedAt = '',
+    ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
 
         $body = [
             'name' => $name,
             'head_sha' => $headSha,
-            'status' => 'completed',
-            'conclusion' => $conclusion,
-            'completed_at' => gmdate('Y-m-d\TH:i:s\Z'),
-            'output' => [
-                'title' => $title,
-                'summary' => $summary,
-            ],
+            'status' => $status,
         ];
 
-        $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
+        if (!empty($detailsUrl)) {
+            $body['details_url'] = $detailsUrl;
+        }
+        if (!empty($externalId)) {
+            $body['external_id'] = $externalId;
+        }
+        if (!empty($startedAt)) {
+            $body['started_at'] = $startedAt;
+        }
+        if (!empty($conclusion)) {
+            $body['conclusion'] = $conclusion;
+        }
+        if (!empty($completedAt)) {
+            $body['completed_at'] = $completedAt;
+        }
+        if (!empty($title) || !empty($summary)) {
+            $body['output'] = [
+                'title' => $title,
+                'summary' => $summary,
+            ];
+            if (!empty($text)) {
+                $body['output']['text'] = $text;
+            }
+        }
+
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => "Bearer $this->accessToken"], $body);
+
+        return $response['body'] ?? [];
+    }
+
+    /**
+     * Gets a check run by ID.
+     *
+     * @return array<mixed>
+     */
+    public function getCheckRun(string $owner, string $repositoryName, int $checkRunId): array
+    {
+        $url = "/repos/$owner/$repositoryName/check-runs/$checkRunId";
+
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "Bearer $this->accessToken"]);
+
+        return $response['body'] ?? [];
     }
 
     /**

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -885,7 +885,7 @@ class GitHub extends Git
             'head_sha' => $headSha,
             'status' => 'completed',
             'conclusion' => $conclusion,
-            'completed_at' => date('Y-m-d\TH:i:s\Z'),
+            'completed_at' => gmdate('Y-m-d\TH:i:s\Z'),
             'output' => [
                 'title' => $title,
                 'summary' => $summary,

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -900,6 +900,14 @@ class GitHub extends Git
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs";
 
+        // Conclusion requires status=completed; auto-set completed_at if not provided.
+        if (!empty($conclusion)) {
+            $status = 'completed';
+            if (empty($completedAt)) {
+                $completedAt = gmdate('Y-m-d\TH:i:s\Z');
+            }
+        }
+
         $body = array_merge(
             [
                 'name' => $name,
@@ -915,7 +923,8 @@ class GitHub extends Git
             ], fn ($value) => !empty($value))
         );
 
-        if (!empty($title) || !empty($summary)) {
+        // Output requires both title and summary.
+        if (!empty($title) && !empty($summary)) {
             $output = array_filter(['title' => $title, 'summary' => $summary, 'text' => $text], fn ($value) => !empty($value));
             if (!empty($annotations)) {
                 $output['annotations'] = $annotations;
@@ -973,6 +982,14 @@ class GitHub extends Git
     ): array {
         $url = "/repos/$owner/$repositoryName/check-runs/$checkRunId";
 
+        // Conclusion requires status=completed; auto-set completed_at if not provided.
+        if (!empty($conclusion)) {
+            $status = 'completed';
+            if (empty($completedAt)) {
+                $completedAt = gmdate('Y-m-d\TH:i:s\Z');
+            }
+        }
+
         $body = array_filter([
             'name' => $name,
             'status' => $status,
@@ -983,7 +1000,8 @@ class GitHub extends Git
             'completed_at' => $completedAt,
         ], fn ($value) => !empty($value));
 
-        if (!empty($title) || !empty($summary)) {
+        // Output requires both title and summary.
+        if (!empty($title) && !empty($summary)) {
             $output = array_filter(['title' => $title, 'summary' => $summary, 'text' => $text], fn ($value) => !empty($value));
             if (!empty($annotations)) {
                 $output['annotations'] = $annotations;

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -874,7 +874,7 @@ class GitHub extends Git
 
     /**
      * Creates a completed check run for a commit.
-     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, stale, timed_out
+     * conclusion can be one of: action_required, cancelled, failure, neutral, success, skipped, timed_out
      */
     public function createCheckRun(string $owner, string $repositoryName, string $headSha, string $name, string $conclusion, string $title, string $summary): void
     {
@@ -885,6 +885,7 @@ class GitHub extends Git
             'head_sha' => $headSha,
             'status' => 'completed',
             'conclusion' => $conclusion,
+            'completed_at' => date('Y-m-d\TH:i:s\Z'),
             'output' => [
                 'title' => $title,
                 'summary' => $summary,

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -659,18 +659,27 @@ class GitHubTest extends Base
             $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
             $commitHash = $commit['commitHash'];
 
-            // Should not throw
-            $this->vcsAdapter->createCheckRun(
-                static::$owner,
-                $repositoryName,
-                $commitHash,
-                'ci/build',
-                'neutral',
-                'Deployment skipped',
-                'Deployment skipped because the commit message contains a skip pattern.'
+            $checkRun = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                status: 'completed',
+                conclusion: 'neutral',
+                title: 'Deployment skipped',
+                summary: 'Deployment skipped because the commit message contains a skip pattern.',
+                completedAt: gmdate('Y-m-d\TH:i:s\Z'),
             );
 
-            $this->assertTrue(true);
+            $this->assertArrayHasKey('id', $checkRun);
+            $this->assertEquals('completed', $checkRun['status']);
+            $this->assertEquals('neutral', $checkRun['conclusion']);
+            $this->assertEquals('ci/build', $checkRun['name']);
+
+            $fetched = $this->vcsAdapter->getCheckRun(static::$owner, $repositoryName, $checkRun['id']);
+            $this->assertEquals($checkRun['id'], $fetched['id']);
+            $this->assertEquals('neutral', $fetched['conclusion']);
+            $this->assertEquals('completed', $fetched['status']);
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
         }

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -873,6 +873,65 @@ class GitHubTest extends Base
         }
     }
 
+    public function testUpdateCheckRunWithInvalidRepository(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->vcsAdapter->updateCheckRun(
+            owner: static::$owner,
+            repositoryName: 'non-existing-repository-' . \uniqid(),
+            checkRunId: 999999999,
+            conclusion: 'success',
+        );
+    }
+
+    public function testUpdateCheckRunWithInvalidId(): void
+    {
+        $repositoryName = 'test-update-check-run-invalid-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->expectException(\Exception::class);
+            $this->vcsAdapter->updateCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                checkRunId: 999999999,
+                conclusion: 'success',
+            );
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testUpdateCheckRunWithMissingConclusion(): void
+    {
+        $repositoryName = 'test-update-check-run-no-conclusion-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash = $commit['commitHash'];
+
+            $checkRun = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                status: 'in_progress',
+            );
+
+            $this->expectException(\Exception::class);
+            $this->vcsAdapter->updateCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                checkRunId: $checkRun['id'],
+                status: 'completed',
+            );
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testGenerateCloneCommand(): void
     {
         $repositoryName = 'test-clone-command-' . \uniqid();

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -685,6 +685,47 @@ class GitHubTest extends Base
         }
     }
 
+    public function testUpdateCheckRun(): void
+    {
+        $repositoryName = 'test-update-check-run-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash = $commit['commitHash'];
+
+            $checkRun = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                status: 'in_progress',
+                startedAt: gmdate('Y-m-d\TH:i:s\Z'),
+            );
+
+            $this->assertArrayHasKey('id', $checkRun);
+            $this->assertEquals('in_progress', $checkRun['status']);
+
+            $updated = $this->vcsAdapter->updateCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                checkRunId: $checkRun['id'],
+                status: 'completed',
+                conclusion: 'neutral',
+                title: 'Deployment skipped',
+                summary: 'Deployment skipped because the branch does not match the configured branch triggers.',
+                completedAt: gmdate('Y-m-d\TH:i:s\Z'),
+            );
+
+            $this->assertEquals($checkRun['id'], $updated['id']);
+            $this->assertEquals('completed', $updated['status']);
+            $this->assertEquals('neutral', $updated['conclusion']);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testGenerateCloneCommand(): void
     {
         $repositoryName = 'test-clone-command-' . \uniqid();

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -669,12 +669,164 @@ class GitHubTest extends Base
             );
 
             $this->assertArrayHasKey('id', $checkRun);
-            $this->assertEquals('in_progress', $checkRun['status']);
+            $this->assertIsInt($checkRun['id']);
             $this->assertEquals('ci/build', $checkRun['name']);
+            $this->assertEquals('in_progress', $checkRun['status']);
+            $this->assertNull($checkRun['conclusion']);
+            $this->assertEquals($commitHash, $checkRun['head_sha']);
+            $this->assertNotEmpty($checkRun['url']);
+            $this->assertNotEmpty($checkRun['html_url']);
+            $this->assertNotEmpty($checkRun['started_at']);
+            $this->assertNull($checkRun['completed_at']);
 
             $fetched = $this->vcsAdapter->getCheckRun(static::$owner, $repositoryName, $checkRun['id']);
             $this->assertEquals($checkRun['id'], $fetched['id']);
+            $this->assertEquals('ci/build', $fetched['name']);
             $this->assertEquals('in_progress', $fetched['status']);
+            $this->assertNull($fetched['conclusion']);
+            $this->assertEquals($commitHash, $fetched['head_sha']);
+            $this->assertNotEmpty($fetched['url']);
+            $this->assertNotEmpty($fetched['html_url']);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testCreateCheckRunWithInvalidRepository(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->vcsAdapter->createCheckRun(
+            owner: static::$owner,
+            repositoryName: 'non-existing-repository-' . \uniqid(),
+            headSha: 'a' . str_repeat('0', 39),
+            name: 'ci/build',
+        );
+    }
+
+    public function testGetCheckRunWithInvalidId(): void
+    {
+        $repositoryName = 'test-get-check-run-invalid-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->expectException(\Exception::class);
+            $this->vcsAdapter->getCheckRun(static::$owner, $repositoryName, 999999999);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testCreateTwoCheckRunsOnSameCommit(): void
+    {
+        $repositoryName = 'test-two-check-runs-same-commit-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash = $commit['commitHash'];
+
+            $first = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                status: 'in_progress',
+            );
+
+            $second = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                status: 'in_progress',
+            );
+
+            $this->assertArrayHasKey('id', $first);
+            $this->assertArrayHasKey('id', $second);
+            $this->assertNotEquals($first['id'], $second['id']);
+            $this->assertEquals($commitHash, $first['head_sha']);
+            $this->assertEquals($commitHash, $second['head_sha']);
+            $this->assertEquals('ci/build', $first['name']);
+            $this->assertEquals('ci/build', $second['name']);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testCreateCheckRunsWithSameNameOnDifferentCommits(): void
+    {
+        $repositoryName = 'test-check-runs-different-commits-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit1 = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash1 = $commit1['commitHash'];
+
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'second.md', '# Second');
+            $commit2 = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash2 = $commit2['commitHash'];
+
+            $first = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash1,
+                name: 'ci/build',
+                status: 'in_progress',
+            );
+
+            $second = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash2,
+                name: 'ci/build',
+                status: 'in_progress',
+            );
+
+            $this->assertArrayHasKey('id', $first);
+            $this->assertArrayHasKey('id', $second);
+            $this->assertNotEquals($first['id'], $second['id']);
+            $this->assertEquals($commitHash1, $first['head_sha']);
+            $this->assertEquals($commitHash2, $second['head_sha']);
+            $this->assertEquals('ci/build', $first['name']);
+            $this->assertEquals('ci/build', $second['name']);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testCreateCheckRunCompleted(): void
+    {
+        $repositoryName = 'test-create-check-run-completed-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash = $commit['commitHash'];
+
+            $checkRun = $this->vcsAdapter->createCheckRun(
+                owner: static::$owner,
+                repositoryName: $repositoryName,
+                headSha: $commitHash,
+                name: 'ci/build',
+                conclusion: 'success',
+                title: 'Build passed',
+                summary: 'All checks passed successfully.',
+            );
+
+            $this->assertArrayHasKey('id', $checkRun);
+            $this->assertIsInt($checkRun['id']);
+            $this->assertEquals('ci/build', $checkRun['name']);
+            $this->assertEquals('completed', $checkRun['status']);
+            $this->assertEquals('success', $checkRun['conclusion']);
+            $this->assertEquals($commitHash, $checkRun['head_sha']);
+            $this->assertNotEmpty($checkRun['url']);
+            $this->assertNotEmpty($checkRun['html_url']);
+            $this->assertNotEmpty($checkRun['completed_at']);
+            $this->assertEquals('Build passed', $checkRun['output']['title']);
+            $this->assertEquals('All checks passed successfully.', $checkRun['output']['summary']);
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
         }

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -649,6 +649,33 @@ class GitHubTest extends Base
         }
     }
 
+    public function testCreateCheckRun(): void
+    {
+        $repositoryName = 'test-create-check-run-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commit = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch);
+            $commitHash = $commit['commitHash'];
+
+            // Should not throw
+            $this->vcsAdapter->createCheckRun(
+                static::$owner,
+                $repositoryName,
+                $commitHash,
+                'ci/build',
+                'neutral',
+                'Deployment skipped',
+                'Deployment skipped because the commit message contains a skip pattern.'
+            );
+
+            $this->assertTrue(true);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testGenerateCloneCommand(): void
     {
         $repositoryName = 'test-clone-command-' . \uniqid();

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -664,22 +664,17 @@ class GitHubTest extends Base
                 repositoryName: $repositoryName,
                 headSha: $commitHash,
                 name: 'ci/build',
-                status: 'completed',
-                conclusion: 'neutral',
-                title: 'Deployment skipped',
-                summary: 'Deployment skipped because the commit message contains a skip pattern.',
-                completedAt: gmdate('Y-m-d\TH:i:s\Z'),
+                status: 'in_progress',
+                startedAt: gmdate('Y-m-d\TH:i:s\Z'),
             );
 
             $this->assertArrayHasKey('id', $checkRun);
-            $this->assertEquals('completed', $checkRun['status']);
-            $this->assertEquals('neutral', $checkRun['conclusion']);
+            $this->assertEquals('in_progress', $checkRun['status']);
             $this->assertEquals('ci/build', $checkRun['name']);
 
             $fetched = $this->vcsAdapter->getCheckRun(static::$owner, $repositoryName, $checkRun['id']);
             $this->assertEquals($checkRun['id'], $fetched['id']);
-            $this->assertEquals('neutral', $fetched['conclusion']);
-            $this->assertEquals('completed', $fetched['status']);
+            $this->assertEquals('in_progress', $fetched['status']);
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
         }


### PR DESCRIPTION
Add createCheckRun() method to post a completed check run with a given conclusion (neutral, success, failure, etc.) using the GitHub Check Runs API, which supports richer conclusions than the legacy Commit Status API.