### PR TITLE
fix(github): drop per-file patch in getPullRequestFiles to bound memory

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -713,7 +713,10 @@ class GitHub extends Git
             ]);
 
             $files = $response['body'] ?? [];
-            $allFiles = array_merge($allFiles, $files);
+            foreach ($files as $file) {
+                unset($file['patch']);
+                $allFiles[] = $file;
+            }
 
             if (\count($files) < $perPage) {
                 break;


### PR DESCRIPTION
## Problem

`GitHub::getPullRequestFiles()` paginates a pull request's files and accumulates the **full GitHub file objects** — including each file's `patch` (the complete unified diff) — into one array before returning:

```php
$files = $response['body'] ?? [];
$allFiles = array_merge($allFiles, $files);
```

`patch` is the only **unbounded** field (KBs–MBs per file) and grows with PR size. A large PR (thousands of files — generated code, lockfiles, vendored deps) materialises **every diff in memory at once** — hundreds of MB in a single request. In a long-running Swoole worker this drives the process toward its memory limit and OOM.

No caller uses `patch`: both consumers (`appwrite/server-ce`'s GitHub events handler and external-PR authorize handler) only read `filename` / `previous_filename` via `array_column()`.

## Fix

Strip `patch` per page while paginating:

```php
$files = $response['body'] ?? [];
foreach ($files as $file) {
    unset($file['patch']);
    $allFiles[] = $file;
}
```

The return shape is preserved (array of file objects keyed by `filename`, `status`, etc.), so existing behaviour and the `array_column($result, 'filename')` assertions in the GitLab/Gitea adapter tests are unaffected. Memory is now bounded to lightweight per-file metadata.

## Test plan

- `php -l` clean.
- No caller reads `patch`; `filename` / `previous_filename` and all other metadata fields remain present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)