### PR TITLE
feat: list tags with glob filtering across all adapters

### DIFF
--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -230,6 +230,16 @@ abstract class Adapter
     abstract public function listBranches(string $owner, string $repositoryName): array;
 
     /**
+     * Lists tags for a given repository, optionally filtered by a glob pattern.
+     *
+     * @param string $owner Owner name of the repository
+     * @param string $repositoryName Name of the repository
+     * @param string $search Glob pattern (e.g. 'v1.*'); empty returns all tags
+     * @return array<string> List of tag names as array
+     */
+    abstract public function listTags(string $owner, string $repositoryName, string $search = ''): array;
+
+    /**
      * Updates status check of each commit
      * state can be one of: error, failure, pending, success
      */

--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -105,4 +105,20 @@ abstract class Git extends Adapter
      * @return array<mixed> List of commit statuses
      */
     abstract public function getCommitStatuses(string $owner, string $repositoryName, string $commitHash): array;
+
+    /**
+     * Filter ref names by a shell glob pattern (e.g. 'v1.*', 'v?.0.0').
+     * An empty pattern returns every name unchanged.
+     *
+     * @param array<string> $names
+     * @return array<string>
+     */
+    protected function matchGlob(array $names, string $pattern): array
+    {
+        if ($pattern === '') {
+            return \array_values($names);
+        }
+
+        return \array_values(\array_filter($names, fn (string $name) => \fnmatch($pattern, $name)));
+    }
 }

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -796,6 +796,34 @@ class GitHub extends Git
     }
 
     /**
+     * Lists tags for a given repository, optionally filtered by a glob pattern.
+     *
+     * Uses GET /repos/{owner}/{repo}/git/matching-refs/tags to fetch every tag ref
+     * in a single call, then filters client-side with the glob pattern.
+     *
+     * @param  string  $owner
+     * @param  string  $repositoryName
+     * @param  string  $search Glob pattern (e.g. 'v1.*'); empty returns all tags
+     * @return array<string> List of tag names
+     */
+    public function listTags(string $owner, string $repositoryName, string $search = ''): array
+    {
+        $url = "/repos/$owner/$repositoryName/git/matching-refs/tags/";
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "Bearer $this->accessToken"]);
+
+        $statusCode = $response['headers']['status-code'] ?? 0;
+        $responseBody = $response['body'] ?? [];
+
+        if ($statusCode < 200 || $statusCode >= 300 || !is_array($responseBody)) {
+            return [];
+        }
+
+        $tags = array_map(fn ($ref) => str_replace('refs/tags/', '', $ref['ref'] ?? ''), $responseBody);
+
+        return $this->matchGlob($tags, $search);
+    }
+
+    /**
      * Get details of a commit using commit hash
      *
      * @param  string  $owner Owner name of the repository

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -762,6 +762,34 @@ class GitLab extends Git
         return $branches;
     }
 
+    public function listTags(string $owner, string $repositoryName, string $search = ''): array
+    {
+        $ownerPath = $this->getOwnerPath($owner);
+        $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
+
+        $tags = [];
+        $page = 1;
+        do {
+            $pagedUrl = "/projects/{$projectPath}/repository/tags?per_page=100&page={$page}";
+            $response = $this->call(self::METHOD_GET, $pagedUrl, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $responseHeaders = $response['headers'] ?? [];
+            $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
+            if ($responseHeadersStatusCode >= 400) {
+                return [];
+            }
+            $responseBody = $response['body'] ?? [];
+            if (!is_array($responseBody) || empty($responseBody)) {
+                break;
+            }
+            foreach ($responseBody as $tag) {
+                $tags[] = $tag['name'] ?? '';
+            }
+            $page++;
+        } while (count($responseBody) === 100);
+
+        return $this->matchGlob($tags, $search);
+    }
+
     public function getCommit(string $owner, string $repositoryName, string $commitHash): array
     {
         $ownerPath = $this->getOwnerPath($owner);

--- a/src/VCS/Adapter/Git/Gitea.php
+++ b/src/VCS/Adapter/Git/Gitea.php
@@ -815,6 +815,61 @@ class Gitea extends Git
     }
 
     /**
+     * Lists tags for a given repository, optionally filtered by a glob pattern.
+     *
+     * @param string $owner Owner of the repository
+     * @param string $repositoryName Name of the repository
+     * @param string $search Glob pattern (e.g. 'v1.*'); empty returns all tags
+     * @return array<string> Array of tag names
+     */
+    public function listTags(string $owner, string $repositoryName, string $search = ''): array
+    {
+        $allTags = [];
+        $perPage = 50;
+        $maxPages = 100;
+
+        for ($currentPage = 1; $currentPage <= $maxPages; $currentPage++) {
+            $url = "/repos/{$owner}/{$repositoryName}/tags?page={$currentPage}&limit={$perPage}";
+
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "token $this->accessToken"], decode: false);
+
+            $responseHeaders = $response['headers'] ?? [];
+            $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
+
+            if ($responseHeadersStatusCode === 404) {
+                return [];
+            }
+
+            if ($responseHeadersStatusCode >= 400) {
+                if ($currentPage === 1) {
+                    throw new Exception("Failed to list tags: HTTP {$responseHeadersStatusCode}", $responseHeadersStatusCode);
+                }
+                break;
+            }
+
+            $responseBody = \json_decode($response['body'] ?? '', true);
+
+            if (!is_array($responseBody)) {
+                break;
+            }
+
+            $pageCount = 0;
+            foreach ($responseBody as $tag) {
+                if (is_array($tag) && array_key_exists('name', $tag)) {
+                    $allTags[] = $tag['name'] ?? '';
+                    $pageCount++;
+                }
+            }
+
+            if ($pageCount < $perPage) {
+                break;
+            }
+        }
+
+        return $this->matchGlob($allTags, $search);
+    }
+
+    /**
      * Get details of a commit using commit hash
      *
      * @param string $owner Owner name of the repository

--- a/src/VCS/Adapter/Git/Gogs.php
+++ b/src/VCS/Adapter/Git/Gogs.php
@@ -537,4 +537,45 @@ class Gogs extends Gitea
 
         return $branches;
     }
+
+    /**
+     * List tags
+     *
+     * Gogs supports listing tags but without pagination parameters.
+     *
+     * @param string $search Glob pattern (e.g. 'v1.*'); empty returns all tags
+     * @return array<string>
+     */
+    public function listTags(string $owner, string $repositoryName, string $search = ''): array
+    {
+        $url = "/repos/{$owner}/{$repositoryName}/tags";
+
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "token $this->accessToken"]);
+
+        $responseHeaders = $response['headers'] ?? [];
+        $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
+
+        if ($responseHeadersStatusCode === 404) {
+            return [];
+        }
+
+        if ($responseHeadersStatusCode >= 400) {
+            throw new Exception("Failed to list tags: HTTP {$responseHeadersStatusCode}", $responseHeadersStatusCode);
+        }
+
+        $responseBody = $response['body'] ?? [];
+
+        if (!is_array($responseBody)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($responseBody as $tag) {
+            if (is_array($tag) && array_key_exists('name', $tag)) {
+                $tags[] = $tag['name'];
+            }
+        }
+
+        return $this->matchGlob($tags, $search);
+    }
 }

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -622,6 +622,31 @@ class GitHubTest extends Base
         $this->assertEmpty($branches);
     }
 
+    public function testListTagsEmptyRepository(): void
+    {
+        $repositoryName = 'test-list-tags-empty-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+
+            $tags = $this->vcsAdapter->listTags(static::$owner, $repositoryName);
+            $this->assertSame([], $tags);
+
+            // Glob against a repo with no tags stays empty
+            $this->assertSame([], $this->vcsAdapter->listTags(static::$owner, $repositoryName, 'v*'));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testListTagsNonExistingRepository(): void
+    {
+        $tags = $this->vcsAdapter->listTags(static::$owner, 'non-existing-repo-' . \uniqid());
+
+        $this->assertSame([], $tags);
+    }
+
     public function testGetLatestCommit(): void
     {
         $repositoryName = 'test-get-latest-commit-' . \uniqid();

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -1093,6 +1093,41 @@ class GitLabTest extends Base
         }
     }
 
+    public function testListTags(): void
+    {
+        $repositoryName = 'test-list-tags-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commitHash = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch)['commitHash'];
+
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v1.0.0', $commitHash);
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v1.1.0', $commitHash);
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v2.0.0', $commitHash);
+
+            $this->assertEqualsCanonicalizing(['v1.0.0', 'v1.1.0', 'v2.0.0'], $this->vcsAdapter->listTags(static::$owner, $repositoryName));
+            $this->assertEqualsCanonicalizing(['v1.0.0', 'v1.1.0'], $this->vcsAdapter->listTags(static::$owner, $repositoryName, 'v1.*'));
+            $this->assertSame(['v2.0.0'], $this->vcsAdapter->listTags(static::$owner, $repositoryName, 'v2.0.0'));
+            $this->assertEmpty($this->vcsAdapter->listTags(static::$owner, $repositoryName, 'nope-*'));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testListTagsEmptyRepo(): void
+    {
+        $repositoryName = 'test-list-tags-empty-' . \uniqid();
+
+        try {
+            $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+            $this->assertSame([], $this->vcsAdapter->listTags(static::$owner, $repositoryName));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testListRepositoryLanguages(): void
     {
         $repositoryName = 'test-list-repository-languages-' . \uniqid();

--- a/tests/VCS/Adapter/GiteaTest.php
+++ b/tests/VCS/Adapter/GiteaTest.php
@@ -1532,6 +1532,54 @@ class GiteaTest extends Base
         }
     }
 
+    public function testListTags(): void
+    {
+        $repositoryName = 'test-list-tags-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $commitHash = $this->vcsAdapter->getLatestCommit(static::$owner, $repositoryName, static::$defaultBranch)['commitHash'];
+
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v1.0.0', $commitHash);
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v1.1.0', $commitHash);
+            $this->vcsAdapter->createTag(static::$owner, $repositoryName, 'v2.0.0', $commitHash);
+
+            $tags = [];
+            for ($attempt = 0; $attempt < 10; $attempt++) {
+                $tags = $this->vcsAdapter->listTags(static::$owner, $repositoryName);
+                if (count($tags) >= 3) {
+                    break;
+                }
+                usleep(500000);
+            }
+
+            $this->assertEqualsCanonicalizing(['v1.0.0', 'v1.1.0', 'v2.0.0'], $tags);
+
+            // Glob filtering
+            $this->assertEqualsCanonicalizing(['v1.0.0', 'v1.1.0'], $this->vcsAdapter->listTags(static::$owner, $repositoryName, 'v1.*'));
+            $this->assertSame(['v2.0.0'], $this->vcsAdapter->listTags(static::$owner, $repositoryName, 'v2.0.0'));
+            $this->assertEmpty($this->vcsAdapter->listTags(static::$owner, $repositoryName, 'nope-*'));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testListTagsEmptyAndMissingRepo(): void
+    {
+        $repositoryName = 'test-list-tags-empty-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+            $this->assertSame([], $this->vcsAdapter->listTags(static::$owner, $repositoryName));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+
+        $this->assertSame([], $this->vcsAdapter->listTags(static::$owner, 'non-existing-repo-' . \uniqid()));
+    }
+
     public function testListRepositoryLanguages(): void
     {
         $repositoryName = 'test-list-repository-languages-' . \uniqid();


### PR DESCRIPTION
## What

Adds `listTags($owner, $repositoryName, $search = '')` to every Git adapter, mirroring `listBranches`. It returns bare tag names, optionally filtered by a shell glob so you can resolve e.g. `v1.*` → `['v1.0.0', 'v1.1.0']` and pass a concrete tag straight into `getRepositoryPresignedUrl`.

## How

- **`Adapter.php`** — abstract `listTags(...)` declaration next to `listBranches`.
- **`Git.php`** — one shared `matchGlob()` helper (empty pattern → all; otherwise `fnmatch`), so the glob logic lives in exactly one place.
- **`GitHub`** — single `git/matching-refs/tags/` call, strips `refs/tags/`, then `matchGlob`.
- **`GitLab` / `Gitea`** — paginate the tags endpoint, then `matchGlob`.
- **`Gogs`** — non-paginated override (mirrors its existing `listBranches` override).
- **`Forgejo`** — inherits from `Gitea`, no code needed.

## Design notes

- **Bare names, not full `refs/tags/...`** — consistent with `listBranches`, and a bare tag name works as the `$ref` for `getRepositoryPresignedUrl` on every provider.
- **Glob is client-side** — no provider does true glob server-side, so tags are fetched (paginated like `listBranches`) and filtered with `fnmatch`. Note this differs from `listBranches`, whose GitHub-only `$search` is a server-side *prefix*; `listTags` intentionally offers uniform glob across all adapters.

## Tests

- Positive + glob + empty/missing cases in `GiteaTest` (covers Gitea/Forgejo/Gogs via inheritance) and `GitLabTest`.
- Empty + non-existing-repo cases in `GitHubTest` (GitHub's `createTag` is unimplemented, so tags can't be seeded there; the glob filtering is exercised via the shared helper in the other suites).
- `pint` and `phpstan --level 8` pass on `src` and `tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)