### PR TITLE
fix: omit Authorization header in listTags when no access token

### DIFF
--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -32,7 +32,7 @@ class GitHub extends Git
 
     protected string $endpoint = 'https://api.github.com';
 
-    protected string $accessToken;
+    protected string $accessToken = '';
 
     protected string $jwtToken;
 
@@ -809,7 +809,8 @@ class GitHub extends Git
     public function listTags(string $owner, string $repositoryName, string $search = ''): array
     {
         $url = "/repos/$owner/$repositoryName/git/matching-refs/tags/";
-        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => "Bearer $this->accessToken"]);
+        $headers = empty($this->accessToken) ? [] : ['Authorization' => "Bearer $this->accessToken"];
+        $response = $this->call(self::METHOD_GET, $url, $headers);
 
         $statusCode = $response['headers']['status-code'] ?? 0;
         $responseBody = $response['body'] ?? [];


### PR DESCRIPTION
## What

`GitHub::listTags` always sent an `Authorization: Bearer <token>` header. When no access token was set, this became an empty `Bearer` value, which GitHub rejects with **401** — even for public repos where matching-refs returns **200** unauthenticated.

## Fix

- Omit the `Authorization` header entirely when there is no access token, so unauthenticated requests to public repos succeed.
- Default `$accessToken` to `''` so `empty()` is safe on an adapter that was never run through `initializeVariables` (avoids accessing an uninitialized typed property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)