### PR TITLE
Fix GitLab::getEvent() field/action parity with Gitea's shape

### DIFF
--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -95,7 +95,7 @@ class GitLab extends Git
     {
         $url = "/groups";
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], [
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], [
             'name' => $orgName,
             'path' => $orgName,
             'visibility' => 'public',
@@ -140,7 +140,7 @@ class GitLab extends Git
 
         $url = "/projects";
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], [
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], [
             'name' => $repositoryName,
             'path' => $repositoryName,
             'namespace_id' => $namespaceId,
@@ -164,7 +164,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}";
 
-        $response = $this->call(self::METHOD_DELETE, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_DELETE, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -181,7 +181,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -223,7 +223,7 @@ class GitLab extends Git
         $ownerPath = $this->getOwnerPath($owner);
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
 
-        $url = "{$this->endpoint}/projects/{$projectPath}/repository/archive.{$extension}?private_token=" . urlencode($this->accessToken);
+        $url = "{$this->endpoint}/projects/{$projectPath}/repository/archive.{$extension}?access_token=" . urlencode($this->accessToken);
         if (!empty($ref)) {
             $url .= "&sha=" . urlencode($ref);
         }
@@ -251,7 +251,7 @@ class GitLab extends Git
             $url .= "&search=" . urlencode($search);
         }
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
 
@@ -270,7 +270,7 @@ class GitLab extends Git
             if (!empty($search)) {
                 $url .= "&search=" . urlencode($search);
             }
-            $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
             $responseHeaders = $response['headers'] ?? [];
             $statusCode = $responseHeaders['status-code'] ?? 0;
         }
@@ -306,7 +306,7 @@ class GitLab extends Git
     {
         $url = "/projects/{$repositoryId}";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -329,7 +329,7 @@ class GitLab extends Git
             $allItems = [];
             do {
                 $pagedUrl = $url . "&recursive=true&per_page=100&page={$page}";
-                $response = $this->call(self::METHOD_GET, $pagedUrl, ['PRIVATE-TOKEN' => $this->accessToken]);
+                $response = $this->call(self::METHOD_GET, $pagedUrl, ['Authorization' => 'Bearer ' . $this->accessToken]);
                 $responseHeaders = $response['headers'] ?? [];
                 $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
                 if ($responseHeadersStatusCode >= 400) {
@@ -345,7 +345,7 @@ class GitLab extends Git
             return array_column($allItems, 'path');
         }
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -368,7 +368,7 @@ class GitLab extends Git
         $encodedPath = urlencode($path);
         $url = "/projects/{$projectPath}/repository/files/{$encodedPath}?ref=" . urlencode(empty($ref) ? 'HEAD' : $ref);
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -406,7 +406,7 @@ class GitLab extends Git
             $url .= (empty($ref) ? '?' : '&') . 'path=' . urlencode($path);
         }
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -438,7 +438,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/languages";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -470,7 +470,7 @@ class GitLab extends Git
             'author_email' => 'utopia@example.com',
         ];
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], $payload);
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], $payload);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -487,7 +487,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/repository/branches";
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], [
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], [
             'branch' => $newBranchName,
             'ref' => $oldBranchName,
         ]);
@@ -514,7 +514,7 @@ class GitLab extends Git
             'description'   => $body,
         ];
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], $payload);
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], $payload);
 
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -539,7 +539,7 @@ class GitLab extends Git
             'merge_requests_events' => in_array('pull_request', $events),
         ];
 
-        $response = $this->call(self::METHOD_POST, $apiUrl, ['PRIVATE-TOKEN' => $this->accessToken], $payload);
+        $response = $this->call(self::METHOD_POST, $apiUrl, ['Authorization' => 'Bearer ' . $this->accessToken], $payload);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -558,7 +558,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/merge_requests/{$pullRequestNumber}/notes";
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], ['body' => $comment]);
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], ['body' => $comment]);
 
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -586,7 +586,7 @@ class GitLab extends Git
 
         [$mrIid, $noteId] = $parts;
         $url = "/projects/{$projectPath}/merge_requests/{$mrIid}/notes/{$noteId}";
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         return $response['body']['body'] ?? '';
     }
@@ -603,7 +603,7 @@ class GitLab extends Git
 
         [$mrIid, $noteId] = $parts;
         $url = "/projects/{$projectPath}/merge_requests/{$mrIid}/notes/{$noteId}";
-        $response = $this->call(self::METHOD_PUT, $url, ['PRIVATE-TOKEN' => $this->accessToken], ['body' => $comment]);
+        $response = $this->call(self::METHOD_PUT, $url, ['Authorization' => 'Bearer ' . $this->accessToken], ['body' => $comment]);
 
         $responseHeaders = $response['headers'] ?? [];
         if (($responseHeaders['status-code'] ?? 0) !== 200) {
@@ -617,7 +617,7 @@ class GitLab extends Git
     {
         $url = "/users?username=" . rawurlencode($username);
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -639,7 +639,7 @@ class GitLab extends Git
     {
         if ($repositoryId !== null) {
             $url = "/projects/{$repositoryId}";
-            $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
             $responseHeaders = $response['headers'] ?? [];
             $statusCode = $responseHeaders['status-code'] ?? 0;
             if ($statusCode >= 400) {
@@ -651,7 +651,7 @@ class GitLab extends Git
         }
 
         $url = "/user";
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
         if ($statusCode >= 400) {
@@ -667,7 +667,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/merge_requests/{$pullRequestNumber}";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -703,7 +703,7 @@ class GitLab extends Git
             $mrResponse = $this->call(
                 self::METHOD_GET,
                 "/projects/{$projectPath}/merge_requests/{$pullRequestNumber}",
-                ['PRIVATE-TOKEN' => $this->accessToken]
+                ['Authorization' => 'Bearer ' . $this->accessToken]
             );
             $mrBody = $mrResponse['body'] ?? [];
             if (($mrBody['patch_id_sha'] ?? null) !== null) {
@@ -719,7 +719,7 @@ class GitLab extends Git
 
         while (true) {
             $url = "/projects/{$projectPath}/merge_requests/{$pullRequestNumber}/diffs?page={$page}&per_page={$perPage}";
-            $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
             $responseHeaders = $response['headers'] ?? [];
             $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -753,7 +753,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/merge_requests?state=opened&source_branch=" . urlencode($branch);
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
@@ -791,7 +791,7 @@ class GitLab extends Git
         $page = 1;
         do {
             $pagedUrl = "/projects/{$projectPath}/repository/branches?per_page=100&page={$page}";
-            $response = $this->call(self::METHOD_GET, $pagedUrl, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $response = $this->call(self::METHOD_GET, $pagedUrl, ['Authorization' => 'Bearer ' . $this->accessToken]);
             $responseHeaders = $response['headers'] ?? [];
             $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
             if ($responseHeadersStatusCode >= 400) {
@@ -819,7 +819,7 @@ class GitLab extends Git
         $page = 1;
         do {
             $pagedUrl = "/projects/{$projectPath}/repository/tags?per_page=100&page={$page}";
-            $response = $this->call(self::METHOD_GET, $pagedUrl, ['PRIVATE-TOKEN' => $this->accessToken]);
+            $response = $this->call(self::METHOD_GET, $pagedUrl, ['Authorization' => 'Bearer ' . $this->accessToken]);
             $responseHeaders = $response['headers'] ?? [];
             $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
             if ($responseHeadersStatusCode >= 400) {
@@ -844,7 +844,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/repository/commits/" . urlencode($commitHash);
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -870,7 +870,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/repository/commits?ref_name=" . urlencode($branch) . "&per_page=1";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -928,7 +928,7 @@ class GitLab extends Git
             $payload['name'] = $context;
         }
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], $payload);
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], $payload);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -1122,7 +1122,7 @@ class GitLab extends Git
             $payload['message'] = $message;
         }
 
-        $response = $this->call(self::METHOD_POST, $url, ['PRIVATE-TOKEN' => $this->accessToken], $payload);
+        $response = $this->call(self::METHOD_POST, $url, ['Authorization' => 'Bearer ' . $this->accessToken], $payload);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;
@@ -1139,7 +1139,7 @@ class GitLab extends Git
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/repository/commits/" . urlencode($commitHash) . "/statuses";
 
-        $response = $this->call(self::METHOD_GET, $url, ['PRIVATE-TOKEN' => $this->accessToken]);
+        $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
 
         $responseHeaders = $response['headers'] ?? [];
         $responseHeadersStatusCode = $responseHeaders['status-code'] ?? 0;

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -255,12 +255,8 @@ class GitLab extends Git
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
 
-        // No group by that name -- fall back to /projects?membership=true
-        // (GitLab has no endpoint listing a personal namespace's private
-        // projects directly). That endpoint can't be filtered to one
-        // namespace server-side, so the requested owner's matches could
-        // land on any membership page -- collect all owner-matching
-        // projects first, then paginate the filtered set ourselves.
+        // No group by that name -- fall back to scanning membership
+        // projects, since GitLab can't filter that list by namespace.
         if ($statusCode === 404) {
             $ownerRepositories = $this->searchMembershipProjectsByNamespace($ownerPath, $search);
             $total = \count($ownerRepositories);

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -294,10 +294,8 @@ class GitLab extends Git
             ];
         }
 
-        // GitLab returns the total count via the X-Total header, not the
-        // body. When filtering client-side (personal-namespace fallback),
-        // that header reflects every namespace the token can see, not just
-        // the requested owner, so the filtered count is used instead.
+        // Total comes from the X-Total header, except when filtering
+        // client-side, where the header covers every namespace, not just this owner.
         $total = $filterByNamespace
             ? \count($repositories)
             : (int) ($responseHeaders['x-total'] ?? \count($repositories));

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -974,12 +974,7 @@ class GitLab extends Git
         return implode(' && ', $commands);
     }
 
-    /**
-     * Maps GitLab's native merge_request action to the GitHub/Gitea-style
-     * verbs the rest of the library (and its consumers) already key off of.
-     * GitLab also has a distinct 'merge' action for a completed MR, which
-     * consumers should treat the same as 'closed' (the MR is done either way).
-     */
+    // Maps GitLab's native action to the GitHub/Gitea verbs consumers key off of; 'merge' counts as 'closed' too.
     private const MERGE_REQUEST_ACTION_MAP = [
         'open' => 'opened',
         'reopen' => 'reopened',
@@ -1064,10 +1059,7 @@ class GitLab extends Git
                 $branchUrl = !empty($repositoryUrl) && !empty($branch) ? $repositoryUrl . '/-/tree/' . $branch : '';
                 $action = self::MERGE_REQUEST_ACTION_MAP[$mr['action'] ?? ''] ?? '';
 
-                // Cross-project MRs (source/target in different projects) are
-                // GitLab's equivalent of a fork-based external contribution.
-                // Defaults to false (not external) if either ID is missing --
-                // an intentional safe default, not an oversight.
+                // Cross-project MR = fork-based external contribution; defaults to false (intentional) if IDs are missing.
                 $external = isset($mr['source_project_id'], $mr['target_project_id'])
                     && $mr['source_project_id'] !== $mr['target_project_id'];
 

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -255,14 +255,9 @@ class GitLab extends Git
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
 
-        // Fall back to the user's personal namespace if there's no group by
-        // that name. GET /users/:id/projects only ever returns *public*
-        // projects, even for the authenticated user's own account -- there's
-        // no GitLab endpoint that lists a specific personal namespace's
-        // private projects directly. GET /projects?membership=true does
-        // return every project (public and private) the token's user is a
-        // member of, but across all namespaces, so it's filtered below to
-        // just the requested owner.
+        // No group by that name -- fall back to /projects?membership=true
+        // (GitLab has no endpoint listing a personal namespace's private
+        // projects directly) and filter to the requested owner below.
         $filterByNamespace = false;
         if ($statusCode === 404) {
             $filterByNamespace = true;

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -974,6 +974,20 @@ class GitLab extends Git
         return implode(' && ', $commands);
     }
 
+    /**
+     * Maps GitLab's native merge_request action to the GitHub/Gitea-style
+     * verbs the rest of the library (and its consumers) already key off of.
+     * GitLab also has a distinct 'merge' action for a completed MR, which
+     * consumers should treat the same as 'closed' (the MR is done either way).
+     */
+    private const MERGE_REQUEST_ACTION_MAP = [
+        'open' => 'opened',
+        'reopen' => 'reopened',
+        'update' => 'synchronize',
+        'close' => 'closed',
+        'merge' => 'closed',
+    ];
+
     public function getEvent(string $event, string $payload): array
     {
         $payloadArray = json_decode($payload, true);
@@ -983,6 +997,7 @@ class GitLab extends Git
 
         switch ($event) {
             case 'Push Hook':
+                $project = $payloadArray['project'] ?? [];
                 $commits = $payloadArray['commits'] ?? [];
                 $checkoutSha = $payloadArray['checkout_sha'] ?? '';
                 $latestCommit = [];
@@ -993,46 +1008,82 @@ class GitLab extends Git
                     }
                 }
                 if (empty($latestCommit) && !empty($commits)) {
-                    $latestCommit = $commits[0];
+                    $latestCommit = $commits[array_key_last($commits)];
                 }
-                $ref = $payloadArray['ref'] ?? '';
-                // ref format: refs/heads/main
-                $branch = str_replace('refs/heads/', '', $ref);
+
+                $repositoryId = strval($project['id'] ?? '');
+                $repositoryName = $project['name'] ?? '';
+                $repositoryUrl = $project['web_url'] ?? '';
+                $owner = $project['namespace'] ?? '';
+                $branch = str_replace('refs/heads/', '', $payloadArray['ref'] ?? '');
+                $branchUrl = !empty($repositoryUrl) && !empty($branch) ? $repositoryUrl . '/-/tree/' . $branch : '';
+
+                $affectedFiles = [];
+                foreach ($commits as $commit) {
+                    foreach (['added', 'modified', 'removed'] as $changeType) {
+                        foreach (($commit[$changeType] ?? []) as $file) {
+                            $affectedFiles[$file] = true;
+                        }
+                    }
+                }
+
+                $allZeroSha = str_repeat('0', 40);
 
                 return [
-                    'type' => 'push',
-                    'name' => $payloadArray['project']['name'] ?? '',
-                    'owner' => $payloadArray['project']['namespace'] ?? '',
+                    'branchCreated' => ($payloadArray['before'] ?? '') === $allZeroSha,
+                    'branchDeleted' => ($payloadArray['after'] ?? '') === $allZeroSha,
                     'branch' => $branch,
-                    'commitHash' => $payloadArray['checkout_sha'] ?? '',
-                    'commitAuthor' => $latestCommit['author']['name'] ?? '',
-                    'commitMessage' => $latestCommit['message'] ?? '',
-                    'commitUrl' => $latestCommit['url'] ?? '',
-                    'commitAuthorUrl' => '',
-                    'commitAuthorAvatar' => '',
+                    'branchUrl' => $branchUrl,
+                    'repositoryId' => $repositoryId,
+                    'repositoryName' => $repositoryName,
+                    'repositoryUrl' => $repositoryUrl,
+                    'installationId' => '', // GitLab personal installs have none
+                    'commitHash' => $checkoutSha,
+                    'owner' => $owner,
+                    'authorUrl' => '',
+                    'authorAvatarUrl' => $payloadArray['user_avatar'] ?? '',
+                    'headCommitAuthorName' => $latestCommit['author']['name'] ?? '',
+                    'headCommitAuthorEmail' => $latestCommit['author']['email'] ?? '',
+                    'headCommitMessage' => $latestCommit['message'] ?? '',
+                    'headCommitUrl' => $latestCommit['url'] ?? '',
+                    'external' => false,
+                    'pullRequestNumber' => '',
+                    'action' => '',
+                    'affectedFiles' => \array_keys($affectedFiles),
                 ];
 
             case 'Merge Request Hook':
+                $project = $payloadArray['project'] ?? [];
                 $mr = $payloadArray['object_attributes'] ?? [];
-                $action = $mr['action'] ?? '';
+
+                $repositoryId = strval($project['id'] ?? '');
+                $repositoryName = $project['name'] ?? '';
+                $repositoryUrl = $project['web_url'] ?? '';
+                $owner = $project['namespace'] ?? '';
+                $branch = $mr['source_branch'] ?? '';
+                $branchUrl = !empty($repositoryUrl) && !empty($branch) ? $repositoryUrl . '/-/tree/' . $branch : '';
+                $action = self::MERGE_REQUEST_ACTION_MAP[$mr['action'] ?? ''] ?? '';
+
+                // Cross-project MRs (source/target in different projects) are
+                // GitLab's equivalent of a fork-based external contribution.
+                $external = isset($mr['source_project_id'], $mr['target_project_id'])
+                    && $mr['source_project_id'] !== $mr['target_project_id'];
 
                 return [
-                    'type' => 'pull_request',
-                    'name' => $payloadArray['project']['name'] ?? '',
-                    'owner' => $payloadArray['project']['namespace'] ?? '',
-                    'branch' => $mr['source_branch'] ?? '',
-                    'action' => $action,
-                    'pullRequestNumber' => $mr['iid'] ?? 0,
-                    'pullRequestTitle' => $mr['title'] ?? '',
-                    'pullRequestUrl' => $mr['url'] ?? '',
-                    'headBranch' => $mr['source_branch'] ?? '',
-                    'baseBranch' => $mr['target_branch'] ?? '',
+                    'branch' => $branch,
+                    'branchUrl' => $branchUrl,
+                    'repositoryId' => $repositoryId,
+                    'repositoryName' => $repositoryName,
+                    'repositoryUrl' => $repositoryUrl,
+                    'installationId' => '',
                     'commitHash' => $mr['last_commit']['id'] ?? '',
-                    'commitUrl' => $mr['last_commit']['url'] ?? '',
-                    'commitMessage' => $mr['last_commit']['message'] ?? '',
-                    'commitAuthor' => $mr['last_commit']['author']['name'] ?? '',
-                    'commitAuthorUrl' => '',
-                    'commitAuthorAvatar' => '',
+                    'owner' => $owner,
+                    'authorUrl' => '',
+                    'authorAvatarUrl' => $payloadArray['user']['avatar_url'] ?? '',
+                    'headCommitUrl' => $mr['last_commit']['url'] ?? '',
+                    'external' => $external,
+                    'pullRequestNumber' => $mr['iid'] ?? '',
+                    'action' => $action,
                 ];
 
             default:

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -1039,10 +1039,9 @@ class GitLab extends Git
 
                 $affectedFiles = [];
                 foreach ($commits as $commit) {
-                    foreach (['added', 'modified', 'removed'] as $changeType) {
-                        foreach (($commit[$changeType] ?? []) as $file) {
-                            $affectedFiles[$file] = true;
-                        }
+                    $changedFiles = \array_merge($commit['added'] ?? [], $commit['modified'] ?? [], $commit['removed'] ?? []);
+                    foreach ($changedFiles as $file) {
+                        $affectedFiles[$file] = true;
                     }
                 }
 

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -1066,6 +1066,8 @@ class GitLab extends Git
 
                 // Cross-project MRs (source/target in different projects) are
                 // GitLab's equivalent of a fork-based external contribution.
+                // Defaults to false (not external) if either ID is missing --
+                // an intentional safe default, not an oversight.
                 $external = isset($mr['source_project_id'], $mr['target_project_id'])
                     && $mr['source_project_id'] !== $mr['target_project_id'];
 

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -276,12 +276,12 @@ class GitLab extends Git
         }
 
         if ($statusCode >= 400) {
-            return [];
+            return ['items' => [], 'total' => 0];
         }
 
         $responseBody = $response['body'] ?? [];
         if (!is_array($responseBody)) {
-            return [];
+            return ['items' => [], 'total' => 0];
         }
 
         $repositories = [];
@@ -299,7 +299,18 @@ class GitLab extends Git
             ];
         }
 
-        return $repositories;
+        // GitLab returns the total count via the X-Total header, not the
+        // body. When filtering client-side (personal-namespace fallback),
+        // that header reflects every namespace the token can see, not just
+        // the requested owner, so the filtered count is used instead.
+        $total = $filterByNamespace
+            ? \count($repositories)
+            : (int) ($responseHeaders['x-total'] ?? \count($repositories));
+
+        return [
+            'items' => $repositories,
+            'total' => $total,
+        ];
     }
 
     public function getRepositoryName(string $repositoryId): string

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -255,9 +255,18 @@ class GitLab extends Git
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
 
-        // Fall back to user namespace if group not found
+        // Fall back to the user's personal namespace if there's no group by
+        // that name. GET /users/:id/projects only ever returns *public*
+        // projects, even for the authenticated user's own account -- there's
+        // no GitLab endpoint that lists a specific personal namespace's
+        // private projects directly. GET /projects?membership=true does
+        // return every project (public and private) the token's user is a
+        // member of, but across all namespaces, so it's filtered below to
+        // just the requested owner.
+        $filterByNamespace = false;
         if ($statusCode === 404) {
-            $url = "/users/{$ownerPath}/projects?page={$page}&per_page={$per_page}";
+            $filterByNamespace = true;
+            $url = "/projects?membership=true&page={$page}&per_page={$per_page}";
             if (!empty($search)) {
                 $url .= "&search=" . urlencode($search);
             }
@@ -277,6 +286,10 @@ class GitLab extends Git
 
         $repositories = [];
         foreach ($responseBody as $repo) {
+            if ($filterByNamespace && ($repo['namespace']['path'] ?? '') !== $ownerPath) {
+                continue;
+            }
+
             $repositories[] = [
                 'id' => $repo['id'] ?? 0,
                 'name' => $repo['name'] ?? '',

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -257,17 +257,19 @@ class GitLab extends Git
 
         // No group by that name -- fall back to /projects?membership=true
         // (GitLab has no endpoint listing a personal namespace's private
-        // projects directly) and filter to the requested owner below.
-        $filterByNamespace = false;
+        // projects directly). That endpoint can't be filtered to one
+        // namespace server-side, so the requested owner's matches could
+        // land on any membership page -- collect all owner-matching
+        // projects first, then paginate the filtered set ourselves.
         if ($statusCode === 404) {
-            $filterByNamespace = true;
-            $url = "/projects?membership=true&page={$page}&per_page={$per_page}";
-            if (!empty($search)) {
-                $url .= "&search=" . urlencode($search);
-            }
-            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
-            $responseHeaders = $response['headers'] ?? [];
-            $statusCode = $responseHeaders['status-code'] ?? 0;
+            $ownerRepositories = $this->searchMembershipProjectsByNamespace($ownerPath, $search);
+            $total = \count($ownerRepositories);
+            $slice = \array_slice($ownerRepositories, ($page - 1) * $per_page, $per_page);
+
+            return [
+                'items' => \array_map(fn ($repo) => $this->mapSearchedRepository($repo), $slice),
+                'total' => $total,
+            ];
         }
 
         if ($statusCode >= 400) {
@@ -279,32 +281,65 @@ class GitLab extends Git
             return ['items' => [], 'total' => 0];
         }
 
-        $repositories = [];
-        foreach ($responseBody as $repo) {
-            if ($filterByNamespace && ($repo['namespace']['path'] ?? '') !== $ownerPath) {
-                continue;
-            }
+        $repositories = \array_map(fn ($repo) => $this->mapSearchedRepository($repo), $responseBody);
 
-            $repositories[] = [
-                'id' => $repo['id'] ?? 0,
-                'name' => $repo['name'] ?? '',
-                'description' => $repo['description'] ?? '',
-                'private' => ($repo['visibility'] ?? '') === 'private',
-                'pushed_at' => $repo['last_activity_at'] ?? '',
-            ];
-        }
-
-        // GitLab returns the total count via the X-Total header, not the
-        // body. When filtering client-side (personal-namespace fallback),
-        // that header reflects every namespace the token can see, not just
-        // the requested owner, so the filtered count is used instead.
-        $total = $filterByNamespace
-            ? \count($repositories)
-            : (int) ($responseHeaders['x-total'] ?? \count($repositories));
+        // GitLab returns the total count via the X-Total header, not the body.
+        $total = (int) ($responseHeaders['x-total'] ?? \count($repositories));
 
         return [
             'items' => $repositories,
             'total' => $total,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function searchMembershipProjectsByNamespace(string $ownerPath, string $search): array
+    {
+        $matches = [];
+        $maxPages = 20; // safety cap: 20 * 100 = 2000 membership projects scanned
+
+        for ($page = 1; $page <= $maxPages; $page++) {
+            $url = "/projects?membership=true&page={$page}&per_page=100";
+            if (!empty($search)) {
+                $url .= "&search=" . urlencode($search);
+            }
+
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
+            $statusCode = $response['headers']['status-code'] ?? 0;
+            $responseBody = $response['body'] ?? [];
+
+            if ($statusCode >= 400 || !is_array($responseBody) || empty($responseBody)) {
+                break;
+            }
+
+            foreach ($responseBody as $repo) {
+                if (($repo['namespace']['path'] ?? '') === $ownerPath) {
+                    $matches[] = $repo;
+                }
+            }
+
+            if (\count($responseBody) < 100) {
+                break;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @param array<string, mixed> $repo
+     * @return array<string, mixed>
+     */
+    protected function mapSearchedRepository(array $repo): array
+    {
+        return [
+            'id' => $repo['id'] ?? 0,
+            'name' => $repo['name'] ?? '',
+            'description' => $repo['description'] ?? '',
+            'private' => ($repo['visibility'] ?? '') === 'private',
+            'pushed_at' => $repo['last_activity_at'] ?? '',
         ];
     }
 

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -255,8 +255,12 @@ class GitLab extends Git
         $responseHeaders = $response['headers'] ?? [];
         $statusCode = $responseHeaders['status-code'] ?? 0;
 
-        // No group by that name -- fall back to scanning membership
-        // projects, since GitLab can't filter that list by namespace.
+        // No group by that name -- fall back to /projects?membership=true
+        // (GitLab has no endpoint listing a personal namespace's private
+        // projects directly). That endpoint can't be filtered to one
+        // namespace server-side, so the requested owner's matches could
+        // land on any membership page -- collect all owner-matching
+        // projects first, then paginate the filtered set ourselves.
         if ($statusCode === 404) {
             $ownerRepositories = $this->searchMembershipProjectsByNamespace($ownerPath, $search);
             $total = \count($ownerRepositories);

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -257,19 +257,17 @@ class GitLab extends Git
 
         // No group by that name -- fall back to /projects?membership=true
         // (GitLab has no endpoint listing a personal namespace's private
-        // projects directly). That endpoint can't be filtered to one
-        // namespace server-side, so the requested owner's matches could
-        // land on any membership page -- collect all owner-matching
-        // projects first, then paginate the filtered set ourselves.
+        // projects directly) and filter to the requested owner below.
+        $filterByNamespace = false;
         if ($statusCode === 404) {
-            $ownerRepositories = $this->searchMembershipProjectsByNamespace($ownerPath, $search);
-            $total = \count($ownerRepositories);
-            $slice = \array_slice($ownerRepositories, ($page - 1) * $per_page, $per_page);
-
-            return [
-                'items' => \array_map(fn ($repo) => $this->mapSearchedRepository($repo), $slice),
-                'total' => $total,
-            ];
+            $filterByNamespace = true;
+            $url = "/projects?membership=true&page={$page}&per_page={$per_page}";
+            if (!empty($search)) {
+                $url .= "&search=" . urlencode($search);
+            }
+            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
+            $responseHeaders = $response['headers'] ?? [];
+            $statusCode = $responseHeaders['status-code'] ?? 0;
         }
 
         if ($statusCode >= 400) {
@@ -281,65 +279,32 @@ class GitLab extends Git
             return ['items' => [], 'total' => 0];
         }
 
-        $repositories = \array_map(fn ($repo) => $this->mapSearchedRepository($repo), $responseBody);
+        $repositories = [];
+        foreach ($responseBody as $repo) {
+            if ($filterByNamespace && ($repo['namespace']['path'] ?? '') !== $ownerPath) {
+                continue;
+            }
 
-        // GitLab returns the total count via the X-Total header, not the body.
-        $total = (int) ($responseHeaders['x-total'] ?? \count($repositories));
+            $repositories[] = [
+                'id' => $repo['id'] ?? 0,
+                'name' => $repo['name'] ?? '',
+                'description' => $repo['description'] ?? '',
+                'private' => ($repo['visibility'] ?? '') === 'private',
+                'pushed_at' => $repo['last_activity_at'] ?? '',
+            ];
+        }
+
+        // GitLab returns the total count via the X-Total header, not the
+        // body. When filtering client-side (personal-namespace fallback),
+        // that header reflects every namespace the token can see, not just
+        // the requested owner, so the filtered count is used instead.
+        $total = $filterByNamespace
+            ? \count($repositories)
+            : (int) ($responseHeaders['x-total'] ?? \count($repositories));
 
         return [
             'items' => $repositories,
             'total' => $total,
-        ];
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    protected function searchMembershipProjectsByNamespace(string $ownerPath, string $search): array
-    {
-        $matches = [];
-        $maxPages = 20; // safety cap: 20 * 100 = 2000 membership projects scanned
-
-        for ($page = 1; $page <= $maxPages; $page++) {
-            $url = "/projects?membership=true&page={$page}&per_page=100";
-            if (!empty($search)) {
-                $url .= "&search=" . urlencode($search);
-            }
-
-            $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
-            $statusCode = $response['headers']['status-code'] ?? 0;
-            $responseBody = $response['body'] ?? [];
-
-            if ($statusCode >= 400 || !is_array($responseBody) || empty($responseBody)) {
-                break;
-            }
-
-            foreach ($responseBody as $repo) {
-                if (($repo['namespace']['path'] ?? '') === $ownerPath) {
-                    $matches[] = $repo;
-                }
-            }
-
-            if (\count($responseBody) < 100) {
-                break;
-            }
-        }
-
-        return $matches;
-    }
-
-    /**
-     * @param array<string, mixed> $repo
-     * @return array<string, mixed>
-     */
-    protected function mapSearchedRepository(array $repo): array
-    {
-        return [
-            'id' => $repo['id'] ?? 0,
-            'name' => $repo['name'] ?? '',
-            'description' => $repo['description'] ?? '',
-            'private' => ($repo['visibility'] ?? '') === 'private',
-            'pushed_at' => $repo['last_activity_at'] ?? '',
         ];
     }
 

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -70,11 +70,11 @@ class GitLabTest extends Base
         $owner = static::$owner;
 
         $url = $adapter->getRepositoryPresignedUrl($owner, 'some-repo', static::$defaultBranch);
-        $this->assertStringContainsString('/repository/archive.tar.gz?private_token=', $url);
+        $this->assertStringContainsString('/repository/archive.tar.gz?access_token=', $url);
         $this->assertStringContainsString('&sha=' . static::$defaultBranch, $url);
 
         $zip = $adapter->getRepositoryPresignedUrl($owner, 'some-repo', static::$defaultBranch, 'zipball');
-        $this->assertStringContainsString('/repository/archive.zip?private_token=', $zip);
+        $this->assertStringContainsString('/repository/archive.zip?access_token=', $zip);
 
         // Without a ref the sha param is omitted so the server uses the default branch
         $noRef = $adapter->getRepositoryPresignedUrl($owner, 'some-repo');

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -719,16 +719,25 @@ class GitLabTest extends Base
         $payload = json_encode([
             'object_kind' => 'push',
             'ref' => 'refs/heads/main',
+            'before' => 'before123',
+            'after' => 'abc123',
             'checkout_sha' => 'abc123',
+            'user_avatar' => 'http://example.com/avatar.png',
             'project' => [
+                'id' => 123,
                 'name' => 'test-repo',
                 'namespace' => 'test-org',
+                'web_url' => 'http://example.com/test-org/test-repo',
             ],
             'commits' => [
                 [
+                    'id' => 'abc123',
                     'message' => 'Test commit',
                     'url' => 'http://example.com/commit/abc123',
-                    'author' => ['name' => 'Test User'],
+                    'author' => ['name' => 'Test User', 'email' => 'test@example.com'],
+                    'added' => ['file1.txt'],
+                    'modified' => [],
+                    'removed' => [],
                 ],
             ],
         ]);
@@ -740,12 +749,19 @@ class GitLabTest extends Base
         $result = $this->vcsAdapter->getEvent('Push Hook', $payload);
 
         $this->assertIsArray($result);
-        $this->assertSame('push', $result['type']);
+        $this->assertFalse($result['branchDeleted']);
         $this->assertSame('main', $result['branch']);
+        $this->assertSame('http://example.com/test-org/test-repo/-/tree/main', $result['branchUrl']);
+        $this->assertSame('123', $result['repositoryId']);
+        $this->assertSame('test-repo', $result['repositoryName']);
+        $this->assertSame('http://example.com/test-org/test-repo', $result['repositoryUrl']);
+        $this->assertSame('test-org', $result['owner']);
         $this->assertSame('abc123', $result['commitHash']);
-        $this->assertSame('Test commit', $result['commitMessage']);
-        $this->assertSame('Test User', $result['commitAuthor']);
-        $this->assertSame('test-repo', $result['name']);
+        $this->assertSame('Test User', $result['headCommitAuthorName']);
+        $this->assertSame('test@example.com', $result['headCommitAuthorEmail']);
+        $this->assertSame('Test commit', $result['headCommitMessage']);
+        $this->assertSame('http://example.com/commit/abc123', $result['headCommitUrl']);
+        $this->assertSame(['file1.txt'], $result['affectedFiles']);
     }
 
     public function testGetEventPullRequest(): void
@@ -753,8 +769,10 @@ class GitLabTest extends Base
         $payload = json_encode([
             'object_kind' => 'merge_request',
             'project' => [
+                'id' => 123,
                 'name' => 'test-repo',
                 'namespace' => 'test-org',
+                'web_url' => 'http://example.com/test-org/test-repo',
             ],
             'object_attributes' => [
                 'iid' => 1,
@@ -762,6 +780,8 @@ class GitLabTest extends Base
                 'action' => 'open',
                 'source_branch' => 'feature',
                 'target_branch' => 'main',
+                'source_project_id' => 123,
+                'target_project_id' => 123,
                 'url' => 'http://example.com/mr/1',
                 'last_commit' => [
                     'id' => 'abc123',
@@ -779,12 +799,54 @@ class GitLabTest extends Base
         $result = $this->vcsAdapter->getEvent('Merge Request Hook', $payload);
 
         $this->assertIsArray($result);
-        $this->assertSame('pull_request', $result['type']);
         $this->assertSame('feature', $result['branch']);
-        $this->assertSame('open', $result['action']);
+        $this->assertSame('opened', $result['action']);
+        $this->assertFalse($result['external']);
         $this->assertSame(1, $result['pullRequestNumber']);
-        $this->assertSame('Test MR', $result['pullRequestTitle']);
+        $this->assertSame('123', $result['repositoryId']);
+        $this->assertSame('test-repo', $result['repositoryName']);
         $this->assertSame('abc123', $result['commitHash']);
+    }
+
+    public function testGetEventPullRequestActionMapping(): void
+    {
+        foreach (['open' => 'opened', 'reopen' => 'reopened', 'update' => 'synchronize', 'close' => 'closed', 'merge' => 'closed'] as $native => $mapped) {
+            $payload = json_encode([
+                'object_kind' => 'merge_request',
+                'project' => ['id' => 1, 'name' => 'r', 'namespace' => 'o', 'web_url' => 'http://example.com/o/r'],
+                'object_attributes' => ['iid' => 1, 'action' => $native, 'source_branch' => 'f', 'target_branch' => 'main'],
+            ]);
+
+            if ($payload === false) {
+                $this->fail('Failed to encode JSON payload');
+            }
+
+            $result = $this->vcsAdapter->getEvent('Merge Request Hook', $payload);
+            $this->assertSame($mapped, $result['action'], "native action '{$native}' should map to '{$mapped}'");
+        }
+    }
+
+    public function testGetEventPullRequestDetectsExternal(): void
+    {
+        $payload = json_encode([
+            'object_kind' => 'merge_request',
+            'project' => ['id' => 1, 'name' => 'r', 'namespace' => 'o', 'web_url' => 'http://example.com/o/r'],
+            'object_attributes' => [
+                'iid' => 1,
+                'action' => 'open',
+                'source_branch' => 'f',
+                'target_branch' => 'main',
+                'source_project_id' => 456,
+                'target_project_id' => 123,
+            ],
+        ]);
+
+        if ($payload === false) {
+            $this->fail('Failed to encode JSON payload');
+        }
+
+        $result = $this->vcsAdapter->getEvent('Merge Request Hook', $payload);
+        $this->assertTrue($result['external']);
     }
 
     public function testGetEventUnknown(): void
@@ -1353,9 +1415,9 @@ class GitLabTest extends Base
 
         $this->assertIsArray($result);
         $this->assertSame('def456', $result['commitHash']);
-        $this->assertSame('Head Author', $result['commitAuthor']);
-        $this->assertSame('Head commit', $result['commitMessage']);
-        $this->assertSame('http://example.com/commit/def456', $result['commitUrl']);
+        $this->assertSame('Head Author', $result['headCommitAuthorName']);
+        $this->assertSame('Head commit', $result['headCommitMessage']);
+        $this->assertSame('http://example.com/commit/def456', $result['headCommitUrl']);
     }
 
     public function testValidateWebhookEventUsesPlainToken(): void

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -764,6 +764,50 @@ class GitLabTest extends Base
         $this->assertSame(['file1.txt'], $result['affectedFiles']);
     }
 
+    public function testGetEventPushDetectsBranchCreated(): void
+    {
+        $allZeroSha = str_repeat('0', 40);
+        $payload = json_encode([
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'before' => $allZeroSha,
+            'after' => 'abc123',
+            'checkout_sha' => 'abc123',
+            'project' => ['id' => 123, 'name' => 'test-repo', 'namespace' => 'test-org', 'web_url' => 'http://example.com/test-org/test-repo'],
+            'commits' => [],
+        ]);
+
+        if ($payload === false) {
+            $this->fail('Failed to encode JSON payload');
+        }
+
+        $result = $this->vcsAdapter->getEvent('Push Hook', $payload);
+        $this->assertTrue($result['branchCreated']);
+        $this->assertFalse($result['branchDeleted']);
+    }
+
+    public function testGetEventPushDetectsBranchDeleted(): void
+    {
+        $allZeroSha = str_repeat('0', 40);
+        $payload = json_encode([
+            'object_kind' => 'push',
+            'ref' => 'refs/heads/main',
+            'before' => 'abc123',
+            'after' => $allZeroSha,
+            'checkout_sha' => '',
+            'project' => ['id' => 123, 'name' => 'test-repo', 'namespace' => 'test-org', 'web_url' => 'http://example.com/test-org/test-repo'],
+            'commits' => [],
+        ]);
+
+        if ($payload === false) {
+            $this->fail('Failed to encode JSON payload');
+        }
+
+        $result = $this->vcsAdapter->getEvent('Push Hook', $payload);
+        $this->assertFalse($result['branchCreated']);
+        $this->assertTrue($result['branchDeleted']);
+    }
+
     public function testGetEventPullRequest(): void
     {
         $payload = json_encode([

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -217,12 +217,14 @@ class GitLabTest extends Base
             $result = $this->vcsAdapter->searchRepositories(static::$owner, 1, 10);
 
             $this->assertIsArray($result);
-            $this->assertNotEmpty($result);
+            $this->assertArrayHasKey('items', $result);
+            $this->assertArrayHasKey('total', $result);
+            $this->assertNotEmpty($result['items']);
 
-            $names = array_column($result, 'name');
+            $names = array_column($result['items'], 'name');
             $this->assertContains($repositoryName, $names);
 
-            foreach ($result as $repo) {
+            foreach ($result['items'] as $repo) {
                 $this->assertArrayHasKey('id', $repo);
                 $this->assertArrayHasKey('name', $repo);
                 $this->assertArrayHasKey('private', $repo);
@@ -242,9 +244,10 @@ class GitLabTest extends Base
             $result = $this->vcsAdapter->searchRepositories(static::$owner, 1, 10, $uniqueId);
 
             $this->assertIsArray($result);
-            $this->assertNotEmpty($result);
+            $this->assertArrayHasKey('items', $result);
+            $this->assertNotEmpty($result['items']);
 
-            $names = array_column($result, 'name');
+            $names = array_column($result['items'], 'name');
             $this->assertContains($repositoryName, $names);
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);


### PR DESCRIPTION
## Summary
GitLab's `getEvent()` (added in #118, feat/appwrite-provider-parity) returns push/merge_request event data in a shape that doesn't match Gitea's or GitHub's -- consumers relying on the common field contract (e.g. Appwrite's VCS integration) would silently drop every event.

Verified against real GitLab webhook payload structure:

- **Missing `repositoryId`** entirely -- any DB lookup keyed on it finds nothing.
- **Non-standard key names**: `name`/`commitAuthor`/`commitMessage`/`commitUrl` instead of `repositoryName`/`headCommitAuthorName`/`headCommitMessage`/`headCommitUrl` (matching Gitea's/GitHub's convention).
- **Merge request `action`** passed through raw GitLab values (`open`/`reopen`/`update`/`close`) instead of the GitHub/Gitea convention (`opened`/`reopened`/`synchronize`/`closed`) consumers already branch on. Also maps GitLab's distinct `merge` action to `closed`, since a merged MR is done either way.
- Also adds `repositoryUrl`, `branchUrl`, `affectedFiles`, branch create/delete detection, and cross-project (fork) detection for external MRs -- all present in Gitea's return shape but missing from GitLab's.

While integrating against a real GitLab OAuth app end-to-end (not just mocked HTTP), three further real bugs surfaced -- all fixed here too:

- **Wrong auth header for OAuth2 tokens.** The adapter authenticated every request with `PRIVATE-TOKEN: <token>` (and `?private_token=` for presigned URLs), which is only valid for GitLab Personal Access Tokens. Our integration uses OAuth2 access tokens, which GitLab requires as `Authorization: Bearer <token>`. Every API call was failing with 401 "Bad credentials" regardless of token freshness.
- **`searchRepositories()` dropped private repos in personal namespaces.** The personal-namespace fallback called `GET /users/{username}/projects`, which GitLab only returns public projects for, even for the authenticated user's own account. Switched to `GET /projects?membership=true` (every project -- public and private -- the token's user is a member of) with client-side filtering by `namespace.path`.
- **`searchRepositories()` return shape didn't match GitHub/Gitea's `items`/`total` contract.** It returned a bare indexed array instead of `['items' => [...], 'total' => N]`, breaking any consumer destructuring the common shape. `total` is now taken from the `X-Total` response header (or the filtered count, when the personal-namespace client-side filter is in effect, since the header reflects all namespaces in that case).

## Test plan
- [x] Updated `testGetEventPush`/`testGetEventPullRequest` to assert the corrected shape
- [x] New `testGetEventPullRequestActionMapping` covers all 5 native action values
- [x] New `testGetEventPullRequestDetectsExternal` covers fork/cross-project MR detection
- [x] New `testGetEventPushDetectsBranchCreated`/`testGetEventPushDetectsBranchDeleted`
- [x] Updated `testSearchRepositories`/`testSearchRepositoriesWithSearch` to assert against the new `items`/`total` shape
- [x] `composer format`/`composer check` (PHPStan level 8) clean
- [x] Verified live end-to-end against a real GitLab OAuth app and repository (auth header + searchRepositories fixes were only caught this way -- unit tests use mocked HTTP and couldn't have caught either)