### PR TITLE
Fix GitLab adapter treating './' as a literal path instead of repository root

### DIFF
--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -128,15 +128,11 @@ class GitLab extends Git
      */
     private function normalizeRepositoryPath(string $path): string
     {
-        if ($path === '.' || $path === './') {
-            return '';
+        while (str_starts_with($path, './')) {
+            $path = substr($path, 2);
         }
 
-        if (str_starts_with($path, './')) {
-            return substr($path, 2);
-        }
-
-        return $path;
+        return $path === '.' ? '' : $path;
     }
 
     /**

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -123,15 +123,8 @@ class GitLab extends Git
     }
 
     /**
-     * Normalize a repository-relative path.
-     *
-     * GitLab's file/tree endpoints receive the path as a literal query
-     * parameter or URL segment value, not a URI path segment, so it is
-     * never subject to dot-segment normalization (unlike e.g. GitHub's
-     * contents API). Callers commonly pass './' or '.' to mean "repository
-     * root" (as `.` conventionally does on POSIX shells and in git itself),
-     * so normalize those to an empty root path and strip a leading './'
-     * from nested paths before they reach the GitLab API.
+     * GitLab passes path as a literal query/URL value, so unlike GitHub it
+     * never resolves './' or '.' to the repository root on its own.
      */
     private function normalizeRepositoryPath(string $path): string
     {

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -123,6 +123,30 @@ class GitLab extends Git
     }
 
     /**
+     * Normalize a repository-relative path.
+     *
+     * GitLab's file/tree endpoints receive the path as a literal query
+     * parameter or URL segment value, not a URI path segment, so it is
+     * never subject to dot-segment normalization (unlike e.g. GitHub's
+     * contents API). Callers commonly pass './' or '.' to mean "repository
+     * root" (as `.` conventionally does on POSIX shells and in git itself),
+     * so normalize those to an empty root path and strip a leading './'
+     * from nested paths before they reach the GitLab API.
+     */
+    private function normalizeRepositoryPath(string $path): string
+    {
+        if ($path === '.' || $path === './') {
+            return '';
+        }
+
+        if (str_starts_with($path, './')) {
+            return substr($path, 2);
+        }
+
+        return $path;
+    }
+
+    /**
      * Extract namespace ID from "id:path" format
      */
     private function getNamespaceId(string $owner): string
@@ -369,7 +393,7 @@ class GitLab extends Git
     {
         $ownerPath = $this->getOwnerPath($owner);
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
-        $encodedPath = urlencode($path);
+        $encodedPath = urlencode($this->normalizeRepositoryPath($path));
         $url = "/projects/{$projectPath}/repository/files/{$encodedPath}?ref=" . urlencode(empty($ref) ? 'HEAD' : $ref);
 
         $response = $this->call(self::METHOD_GET, $url, ['Authorization' => 'Bearer ' . $this->accessToken]);
@@ -402,11 +426,13 @@ class GitLab extends Git
 
     public function listRepositoryContents(string $owner, string $repositoryName, string $path = '', string $ref = ''): array
     {
+        $path = $this->normalizeRepositoryPath($path);
+
         $ownerPath = $this->getOwnerPath($owner);
         $projectPath = urlencode("{$ownerPath}/{$repositoryName}");
         $url = "/projects/{$projectPath}/repository/tree" . (empty($ref) ? '' : '?ref=' . urlencode($ref));
 
-        if (!empty($path)) {
+        if ($path !== '') {
             $url .= (empty($ref) ? '?' : '&') . 'path=' . urlencode($path);
         }
 

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -128,11 +128,12 @@ class GitLab extends Git
      */
     private function normalizeRepositoryPath(string $path): string
     {
-        while (str_starts_with($path, './')) {
-            $path = substr($path, 2);
-        }
+        $segments = array_filter(
+            explode('/', $path),
+            fn (string $segment): bool => $segment !== '' && $segment !== '.'
+        );
 
-        return $path === '.' ? '' : $path;
+        return implode('/', $segments);
     }
 
     /**

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -1347,6 +1347,26 @@ class GitLabTest extends Base
         }
     }
 
+    public function testListRepositoryContentsMalformedNestedPath(): void
+    {
+        $repositoryName = 'test-list-repository-contents-malformed-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'src/main.php', '<?php');
+
+            $clean = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, 'src');
+            $embeddedDot = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, 'src/.');
+            $doubleSlash = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, 'src//');
+
+            $this->assertNotEmpty($clean);
+            $this->assertEquals(array_column($clean, 'name'), array_column($embeddedDot, 'name'));
+            $this->assertEquals(array_column($clean, 'name'), array_column($doubleSlash, 'name'));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testGetUser(): void
     {
         $result = $this->vcsAdapter->getUser('root');

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -1317,9 +1317,12 @@ class GitLabTest extends Base
             $dot = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, '.');
             $dotSlash = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, './');
 
+            $repeatedDotSlash = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, './././');
+
             $this->assertNotEmpty($empty);
             $this->assertEquals(array_column($empty, 'name'), array_column($dot, 'name'));
             $this->assertEquals(array_column($empty, 'name'), array_column($dotSlash, 'name'));
+            $this->assertEquals(array_column($empty, 'name'), array_column($repeatedDotSlash, 'name'));
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
         }
@@ -1335,8 +1338,10 @@ class GitLabTest extends Base
 
             $direct = $this->vcsAdapter->getRepositoryContent(static::$owner, $repositoryName, 'README.md');
             $prefixed = $this->vcsAdapter->getRepositoryContent(static::$owner, $repositoryName, './README.md');
+            $repeatedPrefix = $this->vcsAdapter->getRepositoryContent(static::$owner, $repositoryName, './././README.md');
 
             $this->assertEquals($direct['content'], $prefixed['content']);
+            $this->assertEquals($direct['content'], $repeatedPrefix['content']);
         } finally {
             $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
         }

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -1305,6 +1305,43 @@ class GitLabTest extends Base
         }
     }
 
+    public function testListRepositoryContentsRootSentinels(): void
+    {
+        $repositoryName = 'test-list-repository-contents-root-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+
+            $empty = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, '');
+            $dot = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, '.');
+            $dotSlash = $this->vcsAdapter->listRepositoryContents(static::$owner, $repositoryName, './');
+
+            $this->assertNotEmpty($empty);
+            $this->assertEquals(array_column($empty, 'name'), array_column($dot, 'name'));
+            $this->assertEquals(array_column($empty, 'name'), array_column($dotSlash, 'name'));
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
+    public function testGetRepositoryContentRootSentinelPrefix(): void
+    {
+        $repositoryName = 'test-get-repository-content-root-' . \uniqid();
+        $this->vcsAdapter->createRepository(static::$owner, $repositoryName, false);
+
+        try {
+            $this->vcsAdapter->createFile(static::$owner, $repositoryName, 'README.md', '# Test');
+
+            $direct = $this->vcsAdapter->getRepositoryContent(static::$owner, $repositoryName, 'README.md');
+            $prefixed = $this->vcsAdapter->getRepositoryContent(static::$owner, $repositoryName, './README.md');
+
+            $this->assertEquals($direct['content'], $prefixed['content']);
+        } finally {
+            $this->vcsAdapter->deleteRepository(static::$owner, $repositoryName);
+        }
+    }
+
     public function testGetUser(): void
     {
         $result = $this->vcsAdapter->getUser('root');


### PR DESCRIPTION
## Summary
GitLab's `repository/tree` and `repository/files/:path` endpoints receive `path` as a literal query parameter / URL segment value, which — unlike GitHub's contents API, where the path is a URI path segment subject to standard dot-segment normalization (RFC 3986 §6.2.2.3) — is never normalized. A caller passing `'./'` or `'.'` to mean "repository root" (the conventional meaning in git/POSIX shells, and what GitHub's adapter tolerates transparently) gets an empty tree or a 404 from GitLab instead, because GitLab looks for a file/directory literally named `.`.

Confirmed empirically: traced a real console request through to the raw value received (`./`, 2 bytes, no encoding artifacts) before concluding this belongs in the adapter rather than being worked around by every caller.

## Changes
- Added `GitLab::normalizeRepositoryPath()`: treats `'./'`/`'.'` as repository root (empty path) and strips a leading `'./'` from nested paths.
- Applied it in `listRepositoryContents()` and `getRepositoryContent()`.
- Added regression tests: `testListRepositoryContentsRootSentinels` (asserts `''`, `'.'`, `'./'` all return the same root listing) and `testGetRepositoryContentRootSentinelPrefix` (asserts `'README.md'` and `'./README.md'` fetch the same file).

## Test plan
- [x] `composer lint` (Pint) clean.
- [x] `composer check` (PHPStan level 8) clean.
- [x] CI integration tests against the real GitLab service (`tests.yml`).