### PR TITLE
feat(gitlab): Dynamic Client Registration (DCR) for self-hosted instances

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
         </testsuite>
         <testsuite name="gitlab">
             <file>./tests/VCS/Adapter/GitLabTest.php</file>
+            <file>./tests/VCS/Adapter/GitLabDcrTest.php</file>
         </testsuite>
         <testsuite name="gogs">
             <file>./tests/VCS/Adapter/GogsTest.php</file>

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -33,6 +33,18 @@ class GitLab extends Git
         $this->endpoint = $this->gitlabUrl . '/api/v4';
     }
 
+    /**
+     * Returns the base GitLab URL as passed to setEndpoint() (e.g.
+     * https://gitlab.mycompany.com) -- not $this->endpoint, which has /api/v4
+     * appended for REST calls. DCR endpoints (/oauth/register,
+     * /.well-known/...) live outside the /api/v4 namespace, so they need this
+     * un-suffixed base URL.
+     */
+    public function getEndpoint(): string
+    {
+        return $this->gitlabUrl;
+    }
+
     public function getName(): string
     {
         return 'gitlab';
@@ -1150,6 +1162,208 @@ class GitLab extends Git
         }
 
         return $response['body'] ?? [];
+    }
+
+    /**
+     * Discover whether a GitLab instance supports Dynamic Client Registration.
+     * Checks the MCP-scoped authorization server metadata document.
+     *
+     * Discovery failure is never fatal -- callers use this to decide whether to
+     * offer DCR or fall back to manual OAuth app credential entry.
+     *
+     * @return string|null The registration_endpoint URL if DCR is supported, null otherwise
+     */
+    public function discoverDcrEndpoint(): ?string
+    {
+        try {
+            $wellKnownUrl = rtrim($this->getEndpoint(), '/') . '/.well-known/oauth-authorization-server/api/v4/mcp';
+
+            $response = $this->callDcr(self::METHOD_GET, $wellKnownUrl);
+
+            if ($response['statusCode'] !== 200 || !$response['isJson']) {
+                return null;
+            }
+
+            $body = $response['body'];
+            if (!is_array($body) || empty($body['registration_endpoint']) || !is_string($body['registration_endpoint'])) {
+                return null;
+            }
+
+            return $body['registration_endpoint'];
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Register Appwrite as an OAuth2 client via Dynamic Client Registration (RFC 7591).
+     * Used for self-hosted GitLab instances where no pre-existing OAuth app exists.
+     *
+     * GitLab supports DCR since 18.6 via POST /oauth/register.
+     * Registers a confidential client (Appwrite can hold a client_secret
+     * securely server-side): token_endpoint_auth_method is client_secret_basic
+     * rather than the public/PKCE "none". The returned client_id and
+     * client_secret must be stored per-installation by the caller; this method
+     * has no side effects of its own.
+     *
+     * @param  string  $redirectUri The Appwrite callback URL for this installation
+     * @return array{client_id: string, client_secret: string, client_name: string, redirect_uris: array<string>}
+     *
+     * @throws Exception If registration fails or the response is malformed
+     */
+    public function registerDynamicClient(string $redirectUri): array
+    {
+        $this->assertHttpUrl($redirectUri, 'redirectUri');
+
+        $registrationUrl = rtrim($this->getEndpoint(), '/') . '/oauth/register';
+
+        $payload = [
+            'client_name' => 'Appwrite VCS Integration',
+            'redirect_uris' => [$redirectUri],
+            'grant_types' => ['authorization_code'],
+            'response_types' => ['code'],
+            'token_endpoint_auth_method' => 'client_secret_basic',
+            'confidential' => true,
+            'scope' => 'api read_user',
+        ];
+
+        $response = $this->callDcr(self::METHOD_POST, $registrationUrl, $payload);
+        $statusCode = $response['statusCode'];
+
+        if ($statusCode === 429) {
+            throw new Exception("GitLab DCR failed: HTTP 429 -- rate limited on {$registrationUrl}. Do not retry automatically; wait before trying again.", 429);
+        }
+
+        if ($statusCode === 404) {
+            throw new Exception("GitLab DCR failed: HTTP 404 -- registration endpoint not found at {$registrationUrl}. This GitLab instance may be older than 18.6, which is required for Dynamic Client Registration support.", 404);
+        }
+
+        if ($statusCode === 403) {
+            throw new Exception("GitLab DCR failed: HTTP 403 -- Dynamic Client Registration is disabled on this instance. Ask your GitLab admin to enable it.", 403);
+        }
+
+        if (!$response['isJson']) {
+            throw new Exception("GitLab DCR failed: HTTP {$statusCode} -- expected a JSON response but received a non-JSON body: " . substr($response['raw'], 0, 500), $statusCode);
+        }
+
+        $body = $response['body'];
+
+        if ($statusCode !== 201) {
+            throw new Exception("GitLab DCR failed: HTTP {$statusCode} -- " . json_encode($body), $statusCode);
+        }
+
+        if (!is_array($body) || empty($body['client_id']) || !is_string($body['client_id'])) {
+            throw new Exception("GitLab DCR failed: response is missing a client_id. Response: " . json_encode($body), $statusCode);
+        }
+
+        if (empty($body['client_secret']) || !is_string($body['client_secret'])) {
+            throw new Exception(
+                'GitLab DCR response missing client_secret for confidential client. ' .
+                'Response: ' . json_encode($body),
+                $statusCode
+            );
+        }
+
+        $responseRedirectUris = $body['redirect_uris'] ?? [];
+        if (!is_array($responseRedirectUris) || !in_array($redirectUri, $responseRedirectUris, true)) {
+            throw new Exception("GitLab DCR failed: registered redirect_uris in the response do not match the requested redirectUri.", $statusCode);
+        }
+
+        return [
+            'client_id' => $body['client_id'],
+            'client_secret' => $body['client_secret'],
+            'client_name' => is_string($body['client_name'] ?? null) ? $body['client_name'] : $payload['client_name'],
+            'redirect_uris' => $responseRedirectUris,
+        ];
+    }
+
+    /**
+     * Validate that a string is a well-formed http(s) URL.
+     *
+     * @throws Exception If the URL is missing a scheme/host or uses an unsupported scheme
+     */
+    private function assertHttpUrl(string $url, string $paramName): void
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new Exception("Invalid {$paramName}: '{$url}' is not a valid URL.");
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            throw new Exception("Invalid {$paramName}: '{$url}' must use the http or https scheme.");
+        }
+    }
+
+    /**
+     * Make an HTTP call to an absolute URL, bypassing the /api/v4 base endpoint.
+     * OAuth/DCR endpoints (/oauth/register, /.well-known/...) live outside the
+     * REST API namespace that the inherited call() method targets.
+     *
+     * Isolated in its own protected method (rather than inline curl calls) so
+     * unit tests can stub GitLab responses by overriding it in a subclass,
+     * without a real GitLab instance or an HTTP mocking library.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array{statusCode: int, body: mixed, raw: string, isJson: bool}
+     */
+    protected function callDcr(string $method, string $url, array $params = []): array
+    {
+        $ch = curl_init($url);
+        if (!$ch) {
+            throw new Exception('Curl failed to initialize');
+        }
+
+        $responseHeaders = [];
+
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['content-type: application/json']);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
+            $len = strlen($header);
+            $parts = explode(':', $header, 2);
+            if (count($parts) === 2) {
+                $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+            }
+            return $len;
+        });
+
+        if ($method !== self::METHOD_GET) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+        }
+
+        if ($this->selfSigned) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
+
+        $responseBody = curl_exec($ch);
+        $responseBody = is_string($responseBody) ? $responseBody : '';
+
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlErrno = curl_errno($ch);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($curlErrno) {
+            throw new Exception("GitLab DCR request failed: {$curlError}", $statusCode);
+        }
+
+        $decodedBody = null;
+        $isJson = false;
+        if ($responseBody !== '') {
+            $decodedBody = json_decode($responseBody, true);
+            $isJson = json_last_error() === JSON_ERROR_NONE;
+        }
+
+        return [
+            'statusCode' => $statusCode,
+            'body' => $isJson ? $decodedBody : null,
+            'raw' => $responseBody,
+            'isJson' => $isJson,
+        ];
     }
 
     public function getCommitStatuses(string $owner, string $repositoryName, string $commitHash): array

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -1152,6 +1152,212 @@ class GitLab extends Git
         return $response['body'] ?? [];
     }
 
+    /**
+     * Discover whether a GitLab instance supports Dynamic Client Registration.
+     * Checks the MCP-scoped authorization server metadata document.
+     *
+     * Discovery failure is never fatal -- callers use this to decide whether to
+     * offer DCR or fall back to manual OAuth app credential entry.
+     *
+     * @param  string  $endpoint The self-hosted GitLab base URL
+     * @return string|null The registration_endpoint URL if DCR is supported, null otherwise
+     */
+    public function discoverDcrEndpoint(string $endpoint): ?string
+    {
+        try {
+            $this->assertHttpUrl($endpoint, 'endpoint');
+            $wellKnownUrl = rtrim($endpoint, '/') . '/.well-known/oauth-authorization-server/api/v4/mcp';
+
+            $response = $this->callDcr(self::METHOD_GET, $wellKnownUrl);
+
+            if ($response['statusCode'] !== 200 || !$response['isJson']) {
+                return null;
+            }
+
+            $body = $response['body'];
+            if (!is_array($body) || empty($body['registration_endpoint']) || !is_string($body['registration_endpoint'])) {
+                return null;
+            }
+
+            return $body['registration_endpoint'];
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Register Appwrite as an OAuth2 client via Dynamic Client Registration (RFC 7591).
+     * Used for self-hosted GitLab instances where no pre-existing OAuth app exists.
+     *
+     * GitLab supports DCR since 18.6 via POST /oauth/register.
+     * Returns a public (PKCE) client -- no client_secret is issued. If GitLab
+     * returns one anyway, registration is treated as a confidential-client
+     * mismatch and rejected outright rather than silently dropping the secret.
+     * The returned client_id must be stored per-installation by the caller; this
+     * method has no side effects of its own.
+     *
+     * @param  string  $endpoint The self-hosted GitLab base URL (e.g. https://gitlab.mycompany.com)
+     * @param  string  $redirectUri The Appwrite callback URL for this installation
+     * @return array{client_id: string, client_name: string, redirect_uris: array<string>}
+     *
+     * @throws Exception If registration fails or the response is malformed
+     */
+    public function registerDynamicClient(string $endpoint, string $redirectUri): array
+    {
+        $this->assertHttpUrl($endpoint, 'endpoint');
+        $this->assertHttpUrl($redirectUri, 'redirectUri');
+
+        $registrationUrl = rtrim($endpoint, '/') . '/oauth/register';
+
+        $payload = [
+            'client_name' => 'Appwrite VCS Integration',
+            'redirect_uris' => [$redirectUri],
+            'grant_types' => ['authorization_code'],
+            'response_types' => ['code'],
+            'token_endpoint_auth_method' => 'none',
+            'scope' => 'api read_user',
+        ];
+
+        $response = $this->callDcr(self::METHOD_POST, $registrationUrl, $payload);
+        $statusCode = $response['statusCode'];
+
+        if ($statusCode === 429) {
+            throw new Exception("GitLab DCR failed: HTTP 429 -- rate limited on {$registrationUrl}. Do not retry automatically; wait before trying again.", 429);
+        }
+
+        if ($statusCode === 404) {
+            throw new Exception("GitLab DCR failed: HTTP 404 -- registration endpoint not found at {$registrationUrl}. This GitLab instance may be older than 18.6, which is required for Dynamic Client Registration support.", 404);
+        }
+
+        if ($statusCode === 403) {
+            throw new Exception("GitLab DCR failed: HTTP 403 -- Dynamic Client Registration is disabled on this instance. Ask your GitLab admin to enable it.", 403);
+        }
+
+        if (!$response['isJson']) {
+            throw new Exception("GitLab DCR failed: HTTP {$statusCode} -- expected a JSON response but received a non-JSON body: " . substr($response['raw'], 0, 500), $statusCode);
+        }
+
+        $body = $response['body'];
+
+        if ($statusCode !== 201) {
+            throw new Exception("GitLab DCR failed: HTTP {$statusCode} -- " . json_encode($body), $statusCode);
+        }
+
+        if (!is_array($body) || empty($body['client_id']) || !is_string($body['client_id'])) {
+            throw new Exception("GitLab DCR failed: response is missing a client_id. Response: " . json_encode($body), $statusCode);
+        }
+
+        $responseRedirectUris = $body['redirect_uris'] ?? [];
+        if (!is_array($responseRedirectUris) || !in_array($redirectUri, $responseRedirectUris, true)) {
+            throw new Exception("GitLab DCR failed: registered redirect_uris in the response do not match the requested redirectUri.", $statusCode);
+        }
+
+        if (!empty($body['client_secret'])) {
+            throw new Exception(
+                'GitLab DCR returned an unexpected client_secret. ' .
+                'This suggests the instance registered a confidential client ' .
+                'rather than a public (PKCE) one. Use manual credential setup ' .
+                'instead of DCR for this instance.',
+                $statusCode
+            );
+        }
+
+        return [
+            'client_id' => $body['client_id'],
+            'client_name' => is_string($body['client_name'] ?? null) ? $body['client_name'] : $payload['client_name'],
+            'redirect_uris' => $responseRedirectUris,
+        ];
+    }
+
+    /**
+     * Validate that a string is a well-formed http(s) URL.
+     *
+     * @throws Exception If the URL is missing a scheme/host or uses an unsupported scheme
+     */
+    private function assertHttpUrl(string $url, string $paramName): void
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new Exception("Invalid {$paramName}: '{$url}' is not a valid URL.");
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            throw new Exception("Invalid {$paramName}: '{$url}' must use the http or https scheme.");
+        }
+    }
+
+    /**
+     * Make an HTTP call to an absolute URL, bypassing the /api/v4 base endpoint.
+     * OAuth/DCR endpoints (/oauth/register, /.well-known/...) live outside the
+     * REST API namespace that the inherited call() method targets.
+     *
+     * Isolated in its own protected method (rather than inline curl calls) so
+     * unit tests can stub GitLab responses by overriding it in a subclass,
+     * without a real GitLab instance or an HTTP mocking library.
+     *
+     * @param  array<string, mixed>  $params
+     * @return array{statusCode: int, body: mixed, raw: string, isJson: bool}
+     */
+    protected function callDcr(string $method, string $url, array $params = []): array
+    {
+        $ch = curl_init($url);
+        if (!$ch) {
+            throw new Exception('Curl failed to initialize');
+        }
+
+        $responseHeaders = [];
+
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['content-type: application/json']);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 0);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($curl, $header) use (&$responseHeaders) {
+            $len = strlen($header);
+            $parts = explode(':', $header, 2);
+            if (count($parts) === 2) {
+                $responseHeaders[strtolower(trim($parts[0]))] = trim($parts[1]);
+            }
+            return $len;
+        });
+
+        if ($method !== self::METHOD_GET) {
+            curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($params));
+        }
+
+        if ($this->selfSigned) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
+
+        $responseBody = curl_exec($ch);
+        $responseBody = is_string($responseBody) ? $responseBody : '';
+
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlErrno = curl_errno($ch);
+        $curlError = curl_error($ch);
+        curl_close($ch);
+
+        if ($curlErrno) {
+            throw new Exception("GitLab DCR request failed: {$curlError}", $statusCode);
+        }
+
+        $decodedBody = null;
+        $isJson = false;
+        if ($responseBody !== '') {
+            $decodedBody = json_decode($responseBody, true);
+            $isJson = json_last_error() === JSON_ERROR_NONE;
+        }
+
+        return [
+            'statusCode' => $statusCode,
+            'body' => $isJson ? $decodedBody : null,
+            'raw' => $responseBody,
+            'isJson' => $isJson,
+        ];
+    }
+
     public function getCommitStatuses(string $owner, string $repositoryName, string $commitHash): array
     {
         $ownerPath = $this->getOwnerPath($owner);

--- a/tests/VCS/Adapter/GitLabDcrTest.php
+++ b/tests/VCS/Adapter/GitLabDcrTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Utopia\Tests\Adapter;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\None;
+use Utopia\Cache\Cache;
+use Utopia\VCS\Adapter\Git\GitLab;
+
+/**
+ * Unit tests for GitLab Dynamic Client Registration (RFC 7591).
+ *
+ * These run without a real GitLab instance: callDcr() is stubbed on
+ * GitLabDcrStub so no network call is ever made.
+ */
+class GitLabDcrTest extends TestCase
+{
+    /**
+     * @param  array{statusCode: int, body: mixed, raw: string, isJson: bool}|callable  $response
+     */
+    private function makeAdapter($response): GitLabDcrStub
+    {
+        $adapter = new GitLabDcrStub(new Cache(new None()));
+        $adapter->response = $response;
+
+        return $adapter;
+    }
+
+    public function testRegisterDynamicClientSuccess(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-123',
+                'client_name' => 'Appwrite VCS Integration',
+                'redirect_uris' => ['https://appwrite.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $result = $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+
+        $this->assertSame('dcr-client-123', $result['client_id']);
+        $this->assertNotEmpty($result['client_id']);
+        $this->assertArrayNotHasKey('client_secret', $result);
+
+        $this->assertCount(1, $adapter->calls);
+        $this->assertSame('POST', $adapter->calls[0]['method']);
+        $this->assertSame('https://gitlab.example.com/oauth/register', $adapter->calls[0]['url']);
+        $this->assertSame('none', $adapter->calls[0]['params']['token_endpoint_auth_method']);
+        $this->assertSame('api read_user', $adapter->calls[0]['params']['scope']);
+        $this->assertSame(['https://appwrite.example.com/callback'], $adapter->calls[0]['params']['redirect_uris']);
+    }
+
+    public function testRegisterDynamicClientThrowsOnUnexpectedClientSecret(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-456',
+                'client_secret' => 'should-never-surface',
+                'redirect_uris' => ['https://appwrite.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/client_secret/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientOldGitLab(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 404,
+            'body' => null,
+            'raw' => 'Not Found',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/18\.6/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientDisabled(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 403,
+            'body' => null,
+            'raw' => 'Forbidden',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/admin/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientRateLimited(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 429,
+            'body' => null,
+            'raw' => 'Too Many Requests',
+            'isJson' => false,
+        ]);
+
+        try {
+            $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+            $this->fail('Expected an exception to be thrown');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('rate limit', strtolower($e->getMessage()));
+        }
+
+        $this->assertCount(1, $adapter->calls, 'A 429 response must not be retried automatically');
+    }
+
+    public function testRegisterDynamicClientMalformedJson(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 500,
+            'body' => null,
+            'raw' => '<html>Internal Server Error</html>',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/non-JSON/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientMissingClientId(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => ['redirect_uris' => ['https://appwrite.example.com/callback']],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/client_id/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientMismatchedRedirectUri(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-789',
+                'redirect_uris' => ['https://someone-else.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/redirect_uris/');
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientStripsTrailingSlash(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-999',
+                'redirect_uris' => ['https://appwrite.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $adapter->registerDynamicClient('https://gitlab.example.com/', 'https://appwrite.example.com/callback');
+
+        $this->assertSame('https://gitlab.example.com/oauth/register', $adapter->calls[0]['url']);
+    }
+
+    public function testRegisterDynamicClientRejectsInvalidEndpoint(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            $this->fail('HTTP call should not be made for an invalid endpoint');
+        });
+
+        $this->expectException(Exception::class);
+        $adapter->registerDynamicClient('not-a-url', 'https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientRejectsInvalidRedirectUri(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            $this->fail('HTTP call should not be made for an invalid redirect URI');
+        });
+
+        $this->expectException(Exception::class);
+        $adapter->registerDynamicClient('https://gitlab.example.com', 'not-a-url');
+    }
+
+    public function testDiscoverDcrEndpointSupported(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 200,
+            'body' => ['registration_endpoint' => 'https://gitlab.example.com/oauth/register'],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $result = $adapter->discoverDcrEndpoint('https://gitlab.example.com');
+
+        $this->assertSame('https://gitlab.example.com/oauth/register', $result);
+        $this->assertSame('GET', $adapter->calls[0]['method']);
+        $this->assertSame(
+            'https://gitlab.example.com/.well-known/oauth-authorization-server/api/v4/mcp',
+            $adapter->calls[0]['url']
+        );
+    }
+
+    public function testDiscoverDcrEndpointNotSupported(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 404,
+            'body' => null,
+            'raw' => 'Not Found',
+            'isJson' => false,
+        ]);
+
+        $this->assertNull($adapter->discoverDcrEndpoint('https://gitlab.example.com'));
+    }
+
+    public function testDiscoverDcrEndpointMissingRegistrationEndpoint(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 200,
+            'body' => ['token_endpoint' => 'https://gitlab.example.com/oauth/token'],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->assertNull($adapter->discoverDcrEndpoint('https://gitlab.example.com'));
+    }
+
+    public function testDiscoverDcrEndpointSwallowsExceptions(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            throw new Exception('network unreachable');
+        });
+
+        $this->assertNull($adapter->discoverDcrEndpoint('https://gitlab.example.com'));
+    }
+
+    public function testDiscoverDcrEndpointRejectsInvalidEndpoint(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            $this->fail('HTTP call should not be made for an invalid endpoint');
+        });
+
+        $this->assertNull($adapter->discoverDcrEndpoint('not-a-url'));
+    }
+}
+
+/**
+ * Test double that stubs the network-calling half of the GitLab adapter
+ * (callDcr) so registerDynamicClient()/discoverDcrEndpoint() can be
+ * exercised without a real GitLab instance.
+ */
+class GitLabDcrStub extends GitLab
+{
+    /** @var array{statusCode: int, body: mixed, raw: string, isJson: bool}|callable */
+    public $response;
+
+    /** @var array<int, array{method: string, url: string, params: array<string, mixed>}> */
+    public array $calls = [];
+
+    public function __construct(Cache $cache)
+    {
+        parent::__construct($cache);
+    }
+
+    protected function callDcr(string $method, string $url, array $params = []): array
+    {
+        $this->calls[] = ['method' => $method, 'url' => $url, 'params' => $params];
+
+        return is_callable($this->response)
+            ? ($this->response)($method, $url, $params)
+            : $this->response;
+    }
+}

--- a/tests/VCS/Adapter/GitLabDcrTest.php
+++ b/tests/VCS/Adapter/GitLabDcrTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Utopia\Tests\Adapter;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\None;
+use Utopia\Cache\Cache;
+use Utopia\VCS\Adapter\Git\GitLab;
+
+class GitLabDcrTest extends TestCase
+{
+    /**
+     * @param  array{statusCode: int, body: mixed, raw: string, isJson: bool}|callable  $response
+     */
+    private function makeAdapter($response, string $endpoint = 'https://gitlab.example.com'): GitLabDcrStub
+    {
+        $adapter = new GitLabDcrStub(new Cache(new None()));
+        $adapter->response = $response;
+        $adapter->setEndpoint($endpoint);
+
+        return $adapter;
+    }
+
+    public function testRegisterDynamicClientSuccess(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-123',
+                'client_secret' => 'dcr-secret-123',
+                'client_name' => 'Appwrite VCS Integration',
+                'redirect_uris' => ['https://appwrite.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $result = $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+
+        $this->assertSame('dcr-client-123', $result['client_id']);
+        $this->assertNotEmpty($result['client_id']);
+        $this->assertArrayHasKey('client_secret', $result);
+        $this->assertIsString($result['client_secret']);
+        $this->assertNotEmpty($result['client_secret']);
+        $this->assertSame('dcr-secret-123', $result['client_secret']);
+
+        $this->assertCount(1, $adapter->calls);
+        $this->assertSame('POST', $adapter->calls[0]['method']);
+        $this->assertSame('https://gitlab.example.com/oauth/register', $adapter->calls[0]['url']);
+        $this->assertSame('client_secret_basic', $adapter->calls[0]['params']['token_endpoint_auth_method']);
+        $this->assertTrue($adapter->calls[0]['params']['confidential']);
+        $this->assertSame('api read_user', $adapter->calls[0]['params']['scope']);
+        $this->assertSame(['https://appwrite.example.com/callback'], $adapter->calls[0]['params']['redirect_uris']);
+    }
+
+    public function testRegisterDynamicClientThrowsWhenClientSecretMissing(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-456',
+                'redirect_uris' => ['https://appwrite.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/client_secret/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientOldGitLab(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 404,
+            'body' => null,
+            'raw' => 'Not Found',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/18\.6/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientDisabled(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 403,
+            'body' => null,
+            'raw' => 'Forbidden',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/admin/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientRateLimited(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 429,
+            'body' => null,
+            'raw' => 'Too Many Requests',
+            'isJson' => false,
+        ]);
+
+        try {
+            $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+            $this->fail('Expected an exception to be thrown');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('rate limit', strtolower($e->getMessage()));
+        }
+
+        $this->assertCount(1, $adapter->calls, 'A 429 response must not be retried automatically');
+    }
+
+    public function testRegisterDynamicClientMalformedJson(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 500,
+            'body' => null,
+            'raw' => '<html>Internal Server Error</html>',
+            'isJson' => false,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/non-JSON/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientMissingClientId(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => ['redirect_uris' => ['https://appwrite.example.com/callback']],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/client_id/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientMismatchedRedirectUri(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 201,
+            'body' => [
+                'client_id' => 'dcr-client-789',
+                'client_secret' => 'dcr-secret-789',
+                'redirect_uris' => ['https://someone-else.example.com/callback'],
+            ],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/redirect_uris/');
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+    }
+
+    public function testRegisterDynamicClientStripsTrailingSlash(): void
+    {
+        $adapter = $this->makeAdapter(
+            [
+                'statusCode' => 201,
+                'body' => [
+                    'client_id' => 'dcr-client-999',
+                    'client_secret' => 'dcr-secret-999',
+                    'redirect_uris' => ['https://appwrite.example.com/callback'],
+                ],
+                'raw' => '{}',
+                'isJson' => true,
+            ],
+            'https://gitlab.example.com/'
+        );
+
+        $adapter->registerDynamicClient('https://appwrite.example.com/callback');
+
+        $this->assertSame('https://gitlab.example.com/oauth/register', $adapter->calls[0]['url']);
+    }
+
+    public function testRegisterDynamicClientRejectsInvalidRedirectUri(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            $this->fail('HTTP call should not be made for an invalid redirect URI');
+        });
+
+        $this->expectException(Exception::class);
+        $adapter->registerDynamicClient('not-a-url');
+    }
+
+    public function testDiscoverDcrEndpointSupported(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 200,
+            'body' => ['registration_endpoint' => 'https://gitlab.example.com/oauth/register'],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $result = $adapter->discoverDcrEndpoint();
+
+        $this->assertSame('https://gitlab.example.com/oauth/register', $result);
+        $this->assertSame('GET', $adapter->calls[0]['method']);
+        $this->assertSame(
+            'https://gitlab.example.com/.well-known/oauth-authorization-server/api/v4/mcp',
+            $adapter->calls[0]['url']
+        );
+    }
+
+    public function testDiscoverDcrEndpointNotSupported(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 404,
+            'body' => null,
+            'raw' => 'Not Found',
+            'isJson' => false,
+        ]);
+
+        $this->assertNull($adapter->discoverDcrEndpoint());
+    }
+
+    public function testDiscoverDcrEndpointMissingRegistrationEndpoint(): void
+    {
+        $adapter = $this->makeAdapter([
+            'statusCode' => 200,
+            'body' => ['token_endpoint' => 'https://gitlab.example.com/oauth/token'],
+            'raw' => '{}',
+            'isJson' => true,
+        ]);
+
+        $this->assertNull($adapter->discoverDcrEndpoint());
+    }
+
+    public function testDiscoverDcrEndpointSwallowsExceptions(): void
+    {
+        $adapter = $this->makeAdapter(function () {
+            throw new Exception('network unreachable');
+        });
+
+        $this->assertNull($adapter->discoverDcrEndpoint());
+    }
+}
+
+/**
+ * Test double that stubs the network-calling half of the GitLab adapter
+ * (callDcr) so registerDynamicClient()/discoverDcrEndpoint() can be
+ * exercised without a real GitLab instance.
+ */
+class GitLabDcrStub extends GitLab
+{
+    /** @var array{statusCode: int, body: mixed, raw: string, isJson: bool}|callable */
+    public $response;
+
+    /** @var array<int, array{method: string, url: string, params: array<string, mixed>}> */
+    public array $calls = [];
+
+    public function __construct(Cache $cache)
+    {
+        parent::__construct($cache);
+    }
+
+    protected function callDcr(string $method, string $url, array $params = []): array
+    {
+        $this->calls[] = ['method' => $method, 'url' => $url, 'params' => $params];
+
+        return is_callable($this->response)
+            ? ($this->response)($method, $url, $params)
+            : $this->response;
+    }
+}

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -4,6 +4,7 @@ namespace Utopia\Tests\Adapter;
 
 use Utopia\Cache\Adapter\None;
 use Utopia\Cache\Cache;
+use Utopia\Fetch\Client;
 use Utopia\System\System;
 use Utopia\Tests\Base;
 use Utopia\VCS\Adapter\Git;
@@ -1546,5 +1547,115 @@ class GitLabTest extends Base
         $this->assertFalse(
             $this->vcsAdapter->validateWebhookEvent($payload, 'wrong-token', $secret)
         );
+    }
+
+    public function testDiscoverDcrEndpoint(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+
+        $endpoint = $adapter->discoverDcrEndpoint();
+
+        if ($endpoint === null) {
+            $this->markTestSkipped('This GitLab instance does not expose Dynamic Client Registration discovery (older than 18.6, or disabled).');
+        }
+
+        $this->assertIsString($endpoint);
+        $this->assertStringContainsString('/oauth/register', $endpoint);
+    }
+
+    public function testDiscoverDcrEndpointUnknownHost(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+        $adapter->setEndpoint('http://gitlab-host-that-does-not-exist:80');
+
+        $endpoint = $adapter->discoverDcrEndpoint();
+
+        $this->assertNull($endpoint);
+    }
+
+    public function testRegisterDynamicClient(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+
+        if ($adapter->discoverDcrEndpoint() === null) {
+            $this->markTestSkipped('Dynamic Client Registration is not available on this GitLab instance.');
+        }
+
+        $redirectUri = 'http://localhost/v1/vcs/gitlab/callback';
+        $result = $adapter->registerDynamicClient($redirectUri);
+
+        $this->assertArrayHasKey('client_id', $result);
+        $this->assertIsString($result['client_id']);
+        $this->assertNotEmpty($result['client_id']);
+        $this->assertArrayHasKey('client_secret', $result);
+        $this->assertIsString($result['client_secret']);
+        $this->assertNotEmpty($result['client_secret']);
+        $this->assertContains($redirectUri, $result['redirect_uris']);
+    }
+
+    public function testRegisterDynamicClientOnUnreachableHost(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+        $adapter->setEndpoint('http://gitlab-host-that-does-not-exist:80');
+
+        $this->expectException(\Exception::class);
+        $adapter->registerDynamicClient('http://localhost/callback');
+    }
+
+    /**
+     * E2E: confirms a dynamically registered client_id is a real, usable GitLab
+     * OAuth application -- not just a well-formed response. Completing the full
+     * authorization_code+PKCE exchange (to then call a repository-listing
+     * endpoint with the resulting user token) would need a browser-less login
+     * session against GitLab's sign-in form; no such harness exists in this
+     * suite, so this checks the strongest thing reachable without one: that
+     * GitLab persisted the application server-side, under the admin-only
+     * /applications endpoint, with the exact name/redirect/confidentiality we
+     * requested.
+     */
+    public function testRegisterDynamicClientPersistsAsGitLabApplication(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+        $gitlabUrl = System::getEnv('TESTS_GITLAB_URL', 'http://gitlab:80');
+
+        if ($adapter->discoverDcrEndpoint() === null) {
+            $this->markTestSkipped('Dynamic Client Registration is not available on this GitLab instance.');
+        }
+
+        $redirectUri = 'http://localhost/v1/vcs/gitlab/callback';
+        $result = $adapter->registerDynamicClient($redirectUri);
+
+        $client = new Client();
+        $client->addHeader('PRIVATE-TOKEN', static::$accessToken);
+        $response = $client->fetch(
+            url: "{$gitlabUrl}/api/v4/applications",
+            method: 'GET'
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $applications = json_decode($response->text(), true);
+        $this->assertIsArray($applications);
+
+        $registeredApplication = null;
+        foreach ($applications as $application) {
+            if (($application['application_id'] ?? null) === $result['client_id']) {
+                $registeredApplication = $application;
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $registeredApplication,
+            'Dynamically registered client_id was not found in GitLab\'s /api/v4/applications list.'
+        );
+        $this->assertSame($redirectUri, $registeredApplication['callback_url']);
+        $this->assertTrue($registeredApplication['confidential']);
+        $this->assertStringContainsString('Appwrite VCS Integration', $registeredApplication['application_name']);
     }
 }

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -1547,4 +1547,59 @@ class GitLabTest extends Base
             $this->vcsAdapter->validateWebhookEvent($payload, 'wrong-token', $secret)
         );
     }
+
+    public function testDiscoverDcrEndpoint(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+        $gitlabUrl = System::getEnv('TESTS_GITLAB_URL', 'http://gitlab:80');
+
+        $endpoint = $adapter->discoverDcrEndpoint($gitlabUrl);
+
+        if ($endpoint === null) {
+            $this->markTestSkipped('This GitLab instance does not expose Dynamic Client Registration discovery (older than 18.6, or disabled).');
+        }
+
+        $this->assertIsString($endpoint);
+        $this->assertStringContainsString('/oauth/register', $endpoint);
+    }
+
+    public function testDiscoverDcrEndpointUnknownHost(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+
+        $endpoint = $adapter->discoverDcrEndpoint('http://gitlab-host-that-does-not-exist:80');
+
+        $this->assertNull($endpoint);
+    }
+
+    public function testRegisterDynamicClient(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+        $gitlabUrl = System::getEnv('TESTS_GITLAB_URL', 'http://gitlab:80');
+
+        if ($adapter->discoverDcrEndpoint($gitlabUrl) === null) {
+            $this->markTestSkipped('Dynamic Client Registration is not available on this GitLab instance.');
+        }
+
+        $redirectUri = 'http://localhost/v1/vcs/gitlab/callback';
+        $result = $adapter->registerDynamicClient($gitlabUrl, $redirectUri);
+
+        $this->assertArrayHasKey('client_id', $result);
+        $this->assertIsString($result['client_id']);
+        $this->assertNotEmpty($result['client_id']);
+        $this->assertArrayNotHasKey('client_secret', $result);
+        $this->assertContains($redirectUri, $result['redirect_uris']);
+    }
+
+    public function testRegisterDynamicClientOnUnreachableHost(): void
+    {
+        /** @var GitLab $adapter */
+        $adapter = $this->vcsAdapter;
+
+        $this->expectException(\Exception::class);
+        $adapter->registerDynamicClient('http://gitlab-host-that-does-not-exist:80', 'http://localhost/callback');
+    }
 }


### PR DESCRIPTION
Adds DCR support (RFC 7591) for self-hosted GitLab 18.6+ instances.

New methods on the GitLab VCS adapter:
- `registerDynamicClient(string $endpoint, string $redirectUri): array` — registers Appwrite as a public PKCE OAuth client via POST /oauth/register, returns client_id (no secret)
- `discoverDcrEndpoint(string $endpoint): ?string` — checks /.well-known/oauth-authorization-server/api/v4/mcp for DCR availability, returns null if unsupported

Key implementation details:
- token_endpoint_auth_method: none (public/PKCE client)
- Throws if GitLab unexpectedly returns client_secret (signals confidential client mismatch)
- Strict redirect_uri match validation on response
- Explicit handling for 404 (old GitLab), 403 (DCR disabled), 429 (rate limited)
- 16 unit tests + E2E tests against real GitLab 18.10

Reference: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/197644