### PR TITLE
refactor(vcs): report the events a delivery describes

### DIFF
--- a/src/VCS/Adapter.php
+++ b/src/VCS/Adapter.php
@@ -216,13 +216,16 @@ abstract class Adapter
     }
 
     /**
-     * Parses webhook event payload
+     * Parses a webhook delivery into the events it describes.
+     *
+     * A delivery usually describes one event, but some providers batch
+     * several into one -- Bitbucket reports every ref a push touched.
      *
      * @param string $event Type of event: push, pull_request etc
      * @param string $payload The webhook payload received from Git provider
-     * @return array<mixed> Parsed payload as a json object
+     * @return array<array<mixed>> Parsed payloads as json objects
      */
-    abstract public function getEvent(string $event, string $payload): array;
+    abstract public function getEvents(string $event, string $payload): array;
 
     /**
      * HTTP header name carrying the webhook event type (e.g. 'x-github-event').

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -1291,9 +1291,9 @@ class GitHub extends Git
      *
      * @param  string  $event Type of event: push, pull_request etc
      * @param  string  $payload The webhook payload received from GitHub
-     * @return array<mixed> Parsed payload as a json object
+     * @return array<array<mixed>> Parsed payloads as json objects
      */
-    public function getEvent(string $event, string $payload): array
+    public function getEvents(string $event, string $payload): array
     {
         $payload = json_decode($payload, true);
 
@@ -1344,7 +1344,7 @@ class GitHub extends Git
                     }
                 }
 
-                return [
+                return [[
                     'branchCreated' => $branchCreated,
                     'branchDeleted' => $branchDeleted,
                     'branch' => $branch,
@@ -1365,7 +1365,7 @@ class GitHub extends Git
                     'pullRequestNumber' => '',
                     'action' => '',
                     'affectedFiles' => \array_keys($affectedFiles),
-                ];
+                ]];
             case 'pull_request':
                 $payloadRepository = $payload['repository'] ?? [];
                 $payloadRepositoryOwner = $payloadRepository['owner'] ?? [];
@@ -1393,7 +1393,7 @@ class GitHub extends Git
                 $baseLogin = $payloadPullRequestBaseUser['login'] ?? '';
                 $external = $headLogin !== $baseLogin;
 
-                return [
+                return [[
                     'branch' => $branch,
                     'branchUrl' => $branchUrl,
                     'repositoryId' => $repositoryId,
@@ -1408,7 +1408,7 @@ class GitHub extends Git
                     'external' => $external,
                     'pullRequestNumber' => $pullRequestNumber,
                     'action' => $action,
-                ];
+                ]];
             case 'installation':
             case 'installation_repositories':
                 $payloadInstallation = $payload['installation'] ?? [];
@@ -1417,11 +1417,11 @@ class GitHub extends Git
                 $action = $payload['action'] ?? '';
                 $userName = $payloadInstallationAccount['login'] ?? '';
 
-                return [
+                return [[
                     'action' => $action,
                     'installationId' => $installationId,
                     'userName' => $userName,
-                ];
+                ]];
         }
 
         return [];

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -1042,7 +1042,7 @@ class GitLab extends Git
         'merge' => 'closed',
     ];
 
-    public function getEvent(string $event, string $payload): array
+    public function getEvents(string $event, string $payload): array
     {
         $payloadArray = json_decode($payload, true);
         if ($payloadArray === null || !is_array($payloadArray)) {
@@ -1082,7 +1082,7 @@ class GitLab extends Git
 
                 $allZeroSha = str_repeat('0', 40);
 
-                return [
+                return [[
                     'branchCreated' => ($payloadArray['before'] ?? '') === $allZeroSha,
                     'branchDeleted' => ($payloadArray['after'] ?? '') === $allZeroSha,
                     'branch' => $branch,
@@ -1103,7 +1103,7 @@ class GitLab extends Git
                     'pullRequestNumber' => '',
                     'action' => '',
                     'affectedFiles' => \array_keys($affectedFiles),
-                ];
+                ]];
 
             case 'Merge Request Hook':
                 $project = $payloadArray['project'] ?? [];
@@ -1121,7 +1121,7 @@ class GitLab extends Git
                 $external = isset($mr['source_project_id'], $mr['target_project_id'])
                     && $mr['source_project_id'] !== $mr['target_project_id'];
 
-                return [
+                return [[
                     'branch' => $branch,
                     'branchUrl' => $branchUrl,
                     'repositoryId' => $repositoryId,
@@ -1136,7 +1136,7 @@ class GitLab extends Git
                     'external' => $external,
                     'pullRequestNumber' => $mr['iid'] ?? '',
                     'action' => $action,
-                ];
+                ]];
 
             default:
                 return [];

--- a/src/VCS/Adapter/Git/Gitea.php
+++ b/src/VCS/Adapter/Git/Gitea.php
@@ -1119,7 +1119,7 @@ class Gitea extends Git
      * @param string $payload The webhook payload received from Gitea
      * @return array<mixed> Parsed payload as an array
      */
-    public function getEvent(string $event, string $payload): array
+    public function getEvents(string $event, string $payload): array
     {
         $payload = json_decode($payload, true);
 
@@ -1166,7 +1166,7 @@ class Gitea extends Git
                     }
                 }
 
-                return [
+                return [[
                     'branchCreated' => $branchCreated,
                     'branchDeleted' => $branchDeleted,
                     'branch' => $branch,
@@ -1187,7 +1187,7 @@ class Gitea extends Git
                     'pullRequestNumber' => '',
                     'action' => '',
                     'affectedFiles' => \array_keys($affectedFiles),
-                ];
+                ]];
 
             case 'pull_request':
                 $payloadRepository = $payload['repository'] ?? [];
@@ -1217,7 +1217,7 @@ class Gitea extends Git
                 $baseRepoFullName = $payloadRepository['full_name'] ?? '';
                 $external = !empty($headRepoFullName) && !empty($baseRepoFullName) && $headRepoFullName !== $baseRepoFullName;
 
-                return [
+                return [[
                     'branch' => $branch,
                     'branchUrl' => $branchUrl,
                     'repositoryId' => $repositoryId,
@@ -1232,7 +1232,7 @@ class Gitea extends Git
                     'external' => $external,
                     'pullRequestNumber' => $pullRequestNumber,
                     'action' => $action,
-                ];
+                ]];
         }
 
         return [];

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -145,7 +145,7 @@ class GitHubTest extends Base
             $this->fail('Failed to encode JSON payload');
         }
 
-        $result = $this->vcsAdapter->getEvent('installation', $payload);
+        $result = $this->vcsAdapter->getEvents('installation', $payload)[0];
 
         $this->assertSame('deleted', $result['action']);
         $this->assertSame('1234', $result['installationId']);

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -145,7 +145,10 @@ class GitHubTest extends Base
             $this->fail('Failed to encode JSON payload');
         }
 
-        $result = $this->vcsAdapter->getEvents('installation', $payload)[0];
+        $events = $this->vcsAdapter->getEvents('installation', $payload);
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertSame('deleted', $result['action']);
         $this->assertSame('1234', $result['installationId']);

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -159,7 +159,7 @@ class GitLabTest extends Base
             $this->fail('Failed to encode JSON payload');
         }
 
-        $result = $this->vcsAdapter->getEvent('Push Hook', $payload);
+        $result = $this->vcsAdapter->getEvents('Push Hook', $payload)[0];
 
         $this->assertIsArray($result);
         $this->assertSame('def456', $result['commitHash']);
@@ -181,7 +181,7 @@ class GitLabTest extends Base
                 $this->fail('Failed to encode JSON payload');
             }
 
-            $result = $this->vcsAdapter->getEvent('Merge Request Hook', $payload);
+            $result = $this->vcsAdapter->getEvents('Merge Request Hook', $payload)[0];
             $this->assertSame($mapped, $result['action'], "native action '{$native}' should map to '{$mapped}'");
         }
     }

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -159,7 +159,10 @@ class GitLabTest extends Base
             $this->fail('Failed to encode JSON payload');
         }
 
-        $result = $this->vcsAdapter->getEvents('Push Hook', $payload)[0];
+        $events = $this->vcsAdapter->getEvents('Push Hook', $payload);
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertIsArray($result);
         $this->assertSame('def456', $result['commitHash']);
@@ -181,7 +184,10 @@ class GitLabTest extends Base
                 $this->fail('Failed to encode JSON payload');
             }
 
-            $result = $this->vcsAdapter->getEvents('Merge Request Hook', $payload)[0];
+            $events = $this->vcsAdapter->getEvents('Merge Request Hook', $payload);
+            $this->assertIsArray($events);
+            $this->assertCount(1, $events);
+            $result = $events[0];
             $this->assertSame($mapped, $result['action'], "native action '{$native}' should map to '{$mapped}'");
         }
     }

--- a/tests/VCS/Base.php
+++ b/tests/VCS/Base.php
@@ -1556,7 +1556,11 @@ abstract class Base extends TestCase
             'Webhook signature did not validate'
         );
 
-        return $this->vcsAdapter->getEvents($eventName, $payload)[0] ?? [];
+        $events = $this->vcsAdapter->getEvents($eventName, $payload);
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+
+        return $events[0];
     }
 
     public function testValidateWebhookEvent(): void
@@ -2312,10 +2316,13 @@ abstract class Base extends TestCase
 
     public function testGetEventPush(): void
     {
-        $result = $this->vcsAdapter->getEvents(
+        $events = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, ['file1.txt'], ['file2.txt'], ['file3.txt'])
-        )[0];
+        );
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertSame(static::$defaultBranch, $result['branch']);
         $this->assertSame(self::EVENT_REPOSITORY_ID, $result['repositoryId']);
@@ -2335,10 +2342,13 @@ abstract class Base extends TestCase
 
     public function testGetEventPushDetectsBranchCreated(): void
     {
-        $result = $this->vcsAdapter->getEvents(
+        $events = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, created: true)
-        )[0];
+        );
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertTrue($result['branchCreated']);
         $this->assertFalse($result['branchDeleted']);
@@ -2346,10 +2356,13 @@ abstract class Base extends TestCase
 
     public function testGetEventPushDetectsBranchDeleted(): void
     {
-        $result = $this->vcsAdapter->getEvents(
+        $events = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, deleted: true)
-        )[0];
+        );
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertFalse($result['branchCreated']);
         $this->assertTrue($result['branchDeleted']);
@@ -2357,7 +2370,10 @@ abstract class Base extends TestCase
 
     public function testGetEventPullRequest(): void
     {
-        $result = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload())[0];
+        $events = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload());
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertSame('opened', $result['action']);
         $this->assertSame(self::EVENT_HEAD_BRANCH, $result['branch']);
@@ -2371,7 +2387,10 @@ abstract class Base extends TestCase
 
     public function testGetEventPullRequestDetectsExternal(): void
     {
-        $result = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload(external: true))[0];
+        $events = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload(external: true));
+        $this->assertIsArray($events);
+        $this->assertCount(1, $events);
+        $result = $events[0];
 
         $this->assertTrue($result['external']);
     }

--- a/tests/VCS/Base.php
+++ b/tests/VCS/Base.php
@@ -1556,7 +1556,7 @@ abstract class Base extends TestCase
             'Webhook signature did not validate'
         );
 
-        return $this->vcsAdapter->getEvent($eventName, $payload);
+        return $this->vcsAdapter->getEvents($eventName, $payload)[0] ?? [];
     }
 
     public function testValidateWebhookEvent(): void
@@ -2312,10 +2312,10 @@ abstract class Base extends TestCase
 
     public function testGetEventPush(): void
     {
-        $result = $this->vcsAdapter->getEvent(
+        $result = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, ['file1.txt'], ['file2.txt'], ['file3.txt'])
-        );
+        )[0];
 
         $this->assertSame(static::$defaultBranch, $result['branch']);
         $this->assertSame(self::EVENT_REPOSITORY_ID, $result['repositoryId']);
@@ -2335,10 +2335,10 @@ abstract class Base extends TestCase
 
     public function testGetEventPushDetectsBranchCreated(): void
     {
-        $result = $this->vcsAdapter->getEvent(
+        $result = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, created: true)
-        );
+        )[0];
 
         $this->assertTrue($result['branchCreated']);
         $this->assertFalse($result['branchDeleted']);
@@ -2346,10 +2346,10 @@ abstract class Base extends TestCase
 
     public function testGetEventPushDetectsBranchDeleted(): void
     {
-        $result = $this->vcsAdapter->getEvent(
+        $result = $this->vcsAdapter->getEvents(
             static::$pushEventName,
             $this->pushPayload(static::$defaultBranch, deleted: true)
-        );
+        )[0];
 
         $this->assertFalse($result['branchCreated']);
         $this->assertTrue($result['branchDeleted']);
@@ -2357,7 +2357,7 @@ abstract class Base extends TestCase
 
     public function testGetEventPullRequest(): void
     {
-        $result = $this->vcsAdapter->getEvent(static::$pullRequestEventName, $this->pullRequestPayload());
+        $result = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload())[0];
 
         $this->assertSame('opened', $result['action']);
         $this->assertSame(self::EVENT_HEAD_BRANCH, $result['branch']);
@@ -2371,7 +2371,7 @@ abstract class Base extends TestCase
 
     public function testGetEventPullRequestDetectsExternal(): void
     {
-        $result = $this->vcsAdapter->getEvent(static::$pullRequestEventName, $this->pullRequestPayload(external: true));
+        $result = $this->vcsAdapter->getEvents(static::$pullRequestEventName, $this->pullRequestPayload(external: true))[0];
 
         $this->assertTrue($result['external']);
     }
@@ -2379,7 +2379,7 @@ abstract class Base extends TestCase
     public function testGetEventInvalidPayload(): void
     {
         $this->expectException(Exception::class);
-        $this->vcsAdapter->getEvent('push', 'invalid json');
+        $this->vcsAdapter->getEvents('push', 'invalid json');
     }
 
     public function testGetEventUnsupportedEvent(): void
@@ -2390,7 +2390,7 @@ abstract class Base extends TestCase
             $this->fail('Failed to encode JSON payload');
         }
 
-        $result = $this->vcsAdapter->getEvent('unsupported_event', $payload);
+        $result = $this->vcsAdapter->getEvents('unsupported_event', $payload);
 
         $this->assertIsArray($result);
         $this->assertEmpty($result);


### PR DESCRIPTION
Splits the webhook-parsing change out of #125 so that PR carries only Bitbucket.

## What changes

`getEvent()` becomes `getEvents()` and returns the events a delivery describes rather than a single event. `getEvent()` no longer exists.

A delivery was read as one event, which holds for every provider on `main` but not for all of them: a Bitbucket push reports each ref it touched in one delivery, and only the first would ever have been seen.

## Shape

Providers here carry one event per delivery, so each returns the one it parsed inside a list. A delivery describing nothing still returns an empty list, which now reads as "no events" rather than "one empty event".

| | before | after |
|---|---|---|
| known event | `['branch' => 'main', ...]` | `[['branch' => 'main', ...]]` |
| unsupported event | `[]` | `[]` |
| invalid payload | throws | throws |

## Follow-ups

- Appwrite consumes the result as a list and loops it.
- #125 then drops the wrapper it currently adds and implements `getEvents()` like the rest.

Green on all six adapters.