### PR TITLE
fix(bitbucket): report that the archive url carries no credential

### DIFF
--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -100,6 +100,16 @@ abstract class Git extends Adapter
     abstract public function createTag(string $owner, string $repositoryName, string $tagName, string $target, string $message = ''): array;
 
     /**
+     * Whether the archive url this adapter hands out carries its own
+     * credential, so a caller that can only fetch a url still reaches a
+     * private repository through it.
+     */
+    public function supportsAuthenticatedArchiveUrl(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get a short-lived URL to download the repository archive.
      *
      * Not every provider offers one, so the default reports it as unsupported

--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -99,11 +99,7 @@ abstract class Git extends Adapter
      */
     abstract public function createTag(string $owner, string $repositoryName, string $tagName, string $target, string $message = ''): array;
 
-    /**
-     * Whether the archive url this adapter hands out carries its own
-     * credential, so a caller that can only fetch a url still reaches a
-     * private repository through it.
-     */
+    /** Whether the archive url reaches a private repository on its own. */
     public function supportsAuthenticatedArchiveUrl(): bool
     {
         return true;

--- a/src/VCS/Adapter/Git/Bitbucket.php
+++ b/src/VCS/Adapter/Git/Bitbucket.php
@@ -1414,6 +1414,17 @@ class Bitbucket extends Git
     }
 
     /**
+     * Bitbucket's archive host takes no credential from the url: a token
+     * offered as basic userinfo is answered with a redirect to a login page,
+     * so what comes back is a login rather than an archive. Its git endpoint
+     * accepts the same token, which is what a caller falls back to.
+     */
+    public function supportsAuthenticatedArchiveUrl(): bool
+    {
+        return false;
+    }
+
+    /**
      * @link https://support.atlassian.com/bitbucket-cloud/kb/how-to-download-repositories-using-the-api/
      *
      * Bitbucket answers this directly instead of redirecting to a signed URL,

--- a/src/VCS/Adapter/Git/Bitbucket.php
+++ b/src/VCS/Adapter/Git/Bitbucket.php
@@ -1414,10 +1414,8 @@ class Bitbucket extends Git
     }
 
     /**
-     * Bitbucket's archive host takes no credential from the url: a token
-     * offered as basic userinfo is answered with a redirect to a login page,
-     * so what comes back is a login rather than an archive. Its git endpoint
-     * accepts the same token, which is what a caller falls back to.
+     * The archive host answers a token in the url with a redirect to a login
+     * page. The git endpoint accepts the same token.
      */
     public function supportsAuthenticatedArchiveUrl(): bool
     {


### PR DESCRIPTION
A Bitbucket site deployment on Cloud never builds. It sits at `Waiting` with `Size 0 B`, no build logs, and nothing in the queue.

## Cause

`getRepositoryPresignedUrl()` puts the token in the url as basic userinfo. Bitbucket's archive host does not take a credential that way — it answers a redirect to a login page, so the fetch lands empty and the build is never queued. Nothing errors.

Measured against production, with the real stored token:

| request | result |
|---|---|
| `x-token-auth:<oauth>@bitbucket.org/…/get/main.tar.gz` | **302, 0 bytes** |
| same url, no auth | 200, 161267 bytes |
| `?access_token=<oauth>` | 403 |
| `Authorization: Bearer <oauth>` | 200, 161267 bytes |
| `git ls-remote https://x-token-auth:<oauth>@…git` | **exit 0** |

Only a header authenticates that host, and the caller fetching the url sends none. The same token is accepted by the git endpoint.

## Change

Adapters report whether their archive url stands on its own. Bitbucket reports false, so a caller clones what it cannot download; every other adapter is unchanged and keeps its default.

The alternative — carrying an auth header to the archive fetch — reaches past the caller into the service that performs it, for a url that works without one anyway.

## Follow-up

Appwrite routes a provider reporting false down the clone path it already owns for template pushes.