### PR TITLE
fix(bitbucket): send the archive credential as a header

### DIFF
--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -99,10 +99,15 @@ abstract class Git extends Adapter
      */
     abstract public function createTag(string $owner, string $repositoryName, string $tagName, string $target, string $message = ''): array;
 
-    /** Whether the archive url reaches a private repository on its own. */
-    public function supportsAuthenticatedArchiveUrl(): bool
+    /**
+     * Headers a caller must send with getRepositoryPresignedUrl() to reach a
+     * private repository.
+     *
+     * @return array<string, string>
+     */
+    public function getRepositoryPresignedUrlHeaders(): array
     {
-        return true;
+        return [];
     }
 
     /**

--- a/src/VCS/Adapter/Git/Bitbucket.php
+++ b/src/VCS/Adapter/Git/Bitbucket.php
@@ -1415,11 +1415,13 @@ class Bitbucket extends Git
 
     /**
      * The archive host answers a token in the url with a redirect to a login
-     * page. The git endpoint accepts the same token.
+     * page, so the credential travels as a header instead.
+     *
+     * @return array<string, string>
      */
-    public function supportsAuthenticatedArchiveUrl(): bool
+    public function getRepositoryPresignedUrlHeaders(): array
     {
-        return false;
+        return ['Authorization' => $this->authorizationHeader()];
     }
 
     /**
@@ -1437,14 +1439,12 @@ class Bitbucket extends Git
             default => throw new Exception("Invalid archive format: {$format}. Use 'tarball' or 'zipball'."),
         };
 
-        $baseUrl = $this->authenticatedBitbucketUrl();
-
         // Bitbucket resolves HEAD to the repository's default branch
         $ref = empty($ref) ? 'HEAD' : $ref;
 
         $encodedRef = rawurlencode($this->resolveRef($owner, $repositoryName, $ref));
 
-        return "{$baseUrl}/{$owner}/{$repositoryName}/get/{$encodedRef}.{$extension}";
+        return "{$this->bitbucketUrl}/{$owner}/{$repositoryName}/get/{$encodedRef}.{$extension}";
     }
 
     public function generateCloneCommand(string $owner, string $repositoryName, string $version, string $versionType, string $directory, string $rootDirectory): string


### PR DESCRIPTION
Follows #129, which added the wrong abstraction. A Bitbucket deployment still never builds.

## Cause

`getRepositoryPresignedUrl()` puts the token in the url as basic userinfo. Bitbucket's archive host takes no credential that way — it answers a redirect to a login page, the fetch lands empty, and the deployment waits on a build that never starts. Nothing errors.

Measured against production with the real stored token:

| request | result |
|---|---|
| `x-token-auth:<oauth>@bitbucket.org/…/get/main.tar.gz` | **302, 0 bytes** |
| `?access_token=<oauth>` | 403 |
| `Authorization: Bearer <oauth>` | **200, 161267 bytes** |
| `Authorization: Basic <email:token>` | **200, 161267 bytes** |

Only a header authenticates that host, and it works for both credential shapes the adapter handles.

## Change

The url is handed over plain and `getRepositoryPresignedUrlHeaders()` says what to send beside it. `authorizationHeader()` already picks Bearer or Basic per credential, so both are covered.

`authenticatedBitbucketUrl()` stays for `generateCloneCommand()` — the git endpoint does accept a credential in the url.

This replaces `supportsAuthenticatedArchiveUrl()` from #129: what a caller needs is the headers to send, not whether the url stands alone. Routing around the archive fetch doesn't work — the builds worker clones only to push a template commit, then hands off through the same url.

## Follow-up

Appwrite passes these headers into the source `DownloadArtifact`, which already accepts them.