### PR TITLE
fix: report a provider failure when reading pull request files

### DIFF
--- a/src/VCS/Adapter/Git/Bitbucket.php
+++ b/src/VCS/Adapter/Git/Bitbucket.php
@@ -1154,12 +1154,12 @@ class Bitbucket extends Git
 
             $responseBody = $response['body'] ?? [];
             if (!is_array($responseBody)) {
-                break;
+                throw new Exception('Pull request files response is not an object.');
             }
 
             $values = $responseBody['values'] ?? [];
             if (!is_array($values)) {
-                break;
+                throw new Exception('Pull request files response is not a list of diffs.');
             }
 
             foreach ($values as $diff) {

--- a/src/VCS/Adapter/Git/GitHub.php
+++ b/src/VCS/Adapter/Git/GitHub.php
@@ -765,7 +765,17 @@ class GitHub extends Git
                 'page' => $currentPage,
             ]);
 
+            $responseHeaders = $response['headers'] ?? [];
+            $statusCode = $responseHeaders['status-code'] ?? 0;
+            if ($statusCode >= 400) {
+                throw new Exception("Failed to get pull request files: HTTP {$statusCode}", $statusCode);
+            }
+
             $files = $response['body'] ?? [];
+            if (!\is_array($files) || !\array_is_list($files)) {
+                throw new Exception('Pull request files response is not a list of files.');
+            }
+
             $allFiles = array_merge($allFiles, $files);
 
             if (\count($files) < $perPage) {

--- a/src/VCS/Adapter/Git/GitLab.php
+++ b/src/VCS/Adapter/Git/GitLab.php
@@ -774,7 +774,11 @@ class GitLab extends Git
             }
 
             $files = $response['body'] ?? [];
-            if (!is_array($files) || empty($files)) {
+            if (!is_array($files) || !\array_is_list($files)) {
+                throw new Exception('Merge request files response is not a list of diffs.');
+            }
+
+            if (empty($files)) {
                 break;
             }
 

--- a/src/VCS/Adapter/Git/Gitea.php
+++ b/src/VCS/Adapter/Git/Gitea.php
@@ -796,6 +796,10 @@ class Gitea extends Git
             }
 
             $files = $response['body'] ?? [];
+            if (!\is_array($files) || !\array_is_list($files)) {
+                throw new Exception('Pull request files response is not a list of files.');
+            }
+
             $allFiles = array_merge($allFiles, $files);
 
             if (\count($files) < $limit) {

--- a/tests/VCS/Adapter/BitbucketTest.php
+++ b/tests/VCS/Adapter/BitbucketTest.php
@@ -51,9 +51,6 @@ class BitbucketTest extends Base
     }
 
     /**
-     * Bitbucket reports a pull request's files as a diffstat page, cursored by
-     * a 'next' link rather than counted against the page size.
-     *
      * @param  array<string>  $filenames
      * @return array<mixed>|string
      */
@@ -66,8 +63,8 @@ class BitbucketTest extends Base
     }
 
     /**
-     * A Bitbucket page is an object, so an error payload carrying no 'values'
-     * is indistinguishable from a page listing no files.
+     * A page is an object here, so an error payload carrying no 'values' is
+     * indistinguishable from a page listing no files.
      *
      * @return array<string, array<mixed>|string>
      */

--- a/tests/VCS/Adapter/BitbucketTest.php
+++ b/tests/VCS/Adapter/BitbucketTest.php
@@ -50,6 +50,32 @@ class BitbucketTest extends Base
         return 'sha256=' . hash_hmac('sha256', $payload, $secret);
     }
 
+    /**
+     * Bitbucket reports a pull request's files as a diffstat page, cursored by
+     * a 'next' link rather than counted against the page size.
+     *
+     * @param  array<string>  $filenames
+     * @return array<mixed>|string
+     */
+    protected function pullRequestFilesPage(array $filenames, bool $last = true): array|string
+    {
+        return [
+            'values' => \array_map(fn (string $filename) => ['new' => ['path' => $filename]], $filenames),
+            'next' => $last ? null : 'https://api.bitbucket.org/2.0/next',
+        ];
+    }
+
+    /**
+     * A Bitbucket page is an object, so an error payload carrying no 'values'
+     * is indistinguishable from a page listing no files.
+     *
+     * @return array<string, array<mixed>|string>
+     */
+    protected function malformedPullRequestFilesBodies(): array
+    {
+        return ['an HTML error page' => '<html>502 Bad Gateway</html>'];
+    }
+
     protected function setupAdapter(): void
     {
         if (empty(static::$accessToken)) {

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -30,8 +30,10 @@ class GitHubTest extends Base
     {
         return 'sha256=' . hash_hmac('sha256', $payload, $secret);
     }
+
     protected static string $eventHeader = 'x-github-event';
     protected static string $signatureHeader = 'x-hub-signature-256';
+    protected static bool $replayAdapterNeedsToken = false;
 
     protected function setupAdapter(): void
     {

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -39,8 +39,6 @@ class GitLabTest extends Base
     }
 
     /**
-     * GitLab reports a merge request's files as diffs keyed by path.
-     *
      * @param  array<string>  $filenames
      * @return array<mixed>|string
      */

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -6,6 +6,7 @@ use Utopia\Cache\Adapter\None;
 use Utopia\Cache\Cache;
 use Utopia\System\System;
 use Utopia\Tests\Base;
+use Utopia\VCS\Adapter\Git;
 use Utopia\VCS\Adapter\Git\GitLab;
 
 class GitLabTest extends Base
@@ -18,6 +19,7 @@ class GitLabTest extends Base
     protected static string $signatureHeader = 'x-gitlab-token';
     protected static string $pushEventName = 'Push Hook';
     protected static string $pullRequestEventName = 'Merge Request Hook';
+    protected static int $pullRequestFilesPageSize = 100;
 
     /** @var array<string> */
     protected static array $pullRequestOpenedActions = ['opened', 'synchronize'];
@@ -34,6 +36,28 @@ class GitLabTest extends Base
     protected function signWebhookPayload(string $payload, string $secret): string
     {
         return $secret;
+    }
+
+    /**
+     * GitLab reports a merge request's files as diffs keyed by path.
+     *
+     * @param  array<string>  $filenames
+     * @return array<mixed>|string
+     */
+    protected function pullRequestFilesPage(array $filenames, bool $last = true): array|string
+    {
+        return \array_map(fn (string $filename) => ['new_path' => $filename], $filenames);
+    }
+
+    /**
+     * @param  array<int, array<mixed>>  $responses
+     */
+    protected function replayAdapter(array $responses): Git
+    {
+        // GitLab waits for the merge request's diff to be ready before paging.
+        \array_unshift($responses, $this->providerResponse(['patch_id_sha' => 'abc123']));
+
+        return parent::replayAdapter($responses);
     }
 
     protected function setupAdapter(): void

--- a/tests/VCS/Base.php
+++ b/tests/VCS/Base.php
@@ -116,14 +116,12 @@ abstract class Base extends TestCase
     protected static bool $supportsPullRequestLookup = true;
 
     /**
-     * Files per page the adapter asks this provider for, and so the count that
-     * tells a full page apart from the last one.
+     * Files per page the adapter asks this provider for.
      */
     protected static int $pullRequestFilesPageSize = 30;
 
     /**
-     * Whether a replay adapter has to be handed a token. GitHub mints its own
-     * from an app, which cannot be done offline, and defaults it instead.
+     * GitHub mints its own token from an app, which cannot be done offline.
      */
     protected static bool $replayAdapterNeedsToken = true;
 
@@ -219,9 +217,8 @@ abstract class Base extends TestCase
     abstract protected function pullRequestPayload(bool $external = false): string;
 
     /**
-     * Build one page of a pull request's files, shaped the way this provider
-     * returns it. $last tells providers that page by cursor rather than by
-     * count that no page follows.
+     * One page of a pull request's files. $last is only read by providers that
+     * page by cursor rather than by count.
      *
      * @param  array<string>  $filenames
      * @return array<mixed>|string
@@ -232,8 +229,8 @@ abstract class Base extends TestCase
     }
 
     /**
-     * Bodies this provider, or something in front of it, can return with a
-     * success status where a page of files was expected.
+     * Bodies this provider can return with a success status where a page of
+     * files was expected.
      *
      * @return array<string, array<mixed>|string>
      */
@@ -1347,11 +1344,8 @@ abstract class Base extends TestCase
     }
 
     /**
-     * The adapter under test, replying from $responses in order instead of
-     * calling out. Paging and provider failures are impractical to provoke on
-     * a live forge, and a failure has to surface as an exception rather than
-     * as a file list built out of an error payload: a webhook that reads an
-     * empty diff silently skips the deployments the push should have made.
+     * The adapter under test, replying from $responses in order. A live forge
+     * cannot be made to page or fail on demand.
      *
      * @param  array<int, array<mixed>>  $responses
      */

--- a/tests/VCS/Base.php
+++ b/tests/VCS/Base.php
@@ -4,6 +4,8 @@ namespace Utopia\Tests;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\None;
+use Utopia\Cache\Cache;
 use Utopia\Fetch\Client;
 use Utopia\System\System;
 use Utopia\VCS\Adapter\Git;
@@ -113,6 +115,18 @@ abstract class Base extends TestCase
 
     protected static bool $supportsPullRequestLookup = true;
 
+    /**
+     * Files per page the adapter asks this provider for, and so the count that
+     * tells a full page apart from the last one.
+     */
+    protected static int $pullRequestFilesPageSize = 30;
+
+    /**
+     * Whether a replay adapter has to be handed a token. GitHub mints its own
+     * from an app, which cannot be done offline, and defaults it instead.
+     */
+    protected static bool $replayAdapterNeedsToken = true;
+
     protected static bool $supportsCommitStatuses = true;
 
     protected static bool $supportsCommitStatusLookup = true;
@@ -203,6 +217,33 @@ abstract class Base extends TestCase
      * opening EVENT_HEAD_BRANCH against the default branch.
      */
     abstract protected function pullRequestPayload(bool $external = false): string;
+
+    /**
+     * Build one page of a pull request's files, shaped the way this provider
+     * returns it. $last tells providers that page by cursor rather than by
+     * count that no page follows.
+     *
+     * @param  array<string>  $filenames
+     * @return array<mixed>|string
+     */
+    protected function pullRequestFilesPage(array $filenames, bool $last = true): array|string
+    {
+        return \array_map(fn (string $filename) => ['filename' => $filename, 'status' => 'added'], $filenames);
+    }
+
+    /**
+     * Bodies this provider, or something in front of it, can return with a
+     * success status where a page of files was expected.
+     *
+     * @return array<string, array<mixed>|string>
+     */
+    protected function malformedPullRequestFilesBodies(): array
+    {
+        return [
+            'an error payload' => ['message' => 'Bad credentials'],
+            'an HTML error page' => '<html>502 Bad Gateway</html>',
+        ];
+    }
 
     protected function setUp(): void
     {
@@ -1302,6 +1343,122 @@ abstract class Base extends TestCase
             $this->assertContains('feature.txt', $filenames);
         } finally {
             $this->discardRepositories($repositoryName);
+        }
+    }
+
+    /**
+     * The adapter under test, replying from $responses in order instead of
+     * calling out. Paging and provider failures are impractical to provoke on
+     * a live forge, and a failure has to surface as an exception rather than
+     * as a file list built out of an error payload: a webhook that reads an
+     * empty diff silently skips the deployments the push should have made.
+     *
+     * @param  array<int, array<mixed>>  $responses
+     */
+    protected function replayAdapter(array $responses): Git
+    {
+        $adapter = $this->getMockBuilder($this->vcsAdapter::class)
+            ->setConstructorArgs([new Cache(new None())])
+            ->onlyMethods(['call'])
+            ->getMock();
+
+        $adapter->method('call')->willReturnCallback(
+            function () use (&$responses): array {
+                return \array_shift($responses) ?? $this->providerResponse([]);
+            }
+        );
+
+        if (static::$replayAdapterNeedsToken) {
+            $adapter->initializeVariables('1', '', null, 'token', null);
+        }
+
+        return $adapter;
+    }
+
+    /**
+     * @param  array<mixed>|string  $body
+     * @return array<mixed>
+     */
+    protected function providerResponse(array|string $body, int $statusCode = 200): array
+    {
+        return [
+            'headers' => ['status-code' => $statusCode],
+            'body' => $body,
+        ];
+    }
+
+    public function testGetPullRequestFilesPaginated(): void
+    {
+        $this->skipUnlessSupported(static::$supportsPullRequestLookup, 'looking up pull requests');
+
+        $pageSize = static::$pullRequestFilesPageSize;
+        $full = \array_map(fn (int $i) => "first-{$i}.txt", \range(0, $pageSize - 1));
+        $adapter = $this->replayAdapter([
+            $this->providerResponse($this->pullRequestFilesPage($full, false)),
+            $this->providerResponse($this->pullRequestFilesPage(['last.txt'])),
+        ]);
+
+        $result = $adapter->getPullRequestFiles(static::$owner, static::EVENT_REPOSITORY_NAME, 1);
+
+        $filenames = array_column($result, 'filename');
+        $this->assertCount($pageSize + 1, $filenames);
+        $this->assertSame('last.txt', $filenames[$pageSize]);
+    }
+
+    public function testGetPullRequestFilesProviderFailure(): void
+    {
+        $this->skipUnlessSupported(static::$supportsPullRequestLookup, 'looking up pull requests');
+
+        foreach ([401, 403, 404, 500] as $statusCode) {
+            $adapter = $this->replayAdapter([
+                $this->providerResponse(['message' => 'Bad credentials'], $statusCode),
+            ]);
+
+            $thrown = null;
+
+            try {
+                $adapter->getPullRequestFiles(static::$owner, static::EVENT_REPOSITORY_NAME, 1);
+            } catch (Exception $e) {
+                $thrown = $e;
+            }
+
+            $this->assertNotNull($thrown, "HTTP {$statusCode} was not reported as a failure");
+            $this->assertSame($statusCode, $thrown->getCode());
+        }
+    }
+
+    public function testGetPullRequestFilesProviderFailureOnLaterPage(): void
+    {
+        $this->skipUnlessSupported(static::$supportsPullRequestLookup, 'looking up pull requests');
+
+        $full = \array_map(fn (int $i) => "first-{$i}.txt", \range(0, static::$pullRequestFilesPageSize - 1));
+        $adapter = $this->replayAdapter([
+            $this->providerResponse($this->pullRequestFilesPage($full, false)),
+            $this->providerResponse(['message' => 'API rate limit exceeded'], 403),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(403);
+
+        $adapter->getPullRequestFiles(static::$owner, static::EVENT_REPOSITORY_NAME, 1);
+    }
+
+    public function testGetPullRequestFilesMalformedBody(): void
+    {
+        $this->skipUnlessSupported(static::$supportsPullRequestLookup, 'looking up pull requests');
+
+        foreach ($this->malformedPullRequestFilesBodies() as $description => $body) {
+            $adapter = $this->replayAdapter([$this->providerResponse($body)]);
+
+            $thrown = null;
+
+            try {
+                $adapter->getPullRequestFiles(static::$owner, static::EVENT_REPOSITORY_NAME, 1);
+            } catch (Exception $e) {
+                $thrown = $e;
+            }
+
+            $this->assertNotNull($thrown, "{$description} was not reported as a failure");
         }
     }
 


### PR DESCRIPTION
## Problem

`getPullRequestFiles()` assumed every response body was a list of file records:

```php
$files = $response['body'] ?? [];
$allFiles = array_merge($allFiles, $files);
```

GitHub checked no status at all, so an authorization, rate-limit or gateway response reached `array_merge()` and raised a `TypeError` — Appwrite reported an unexpected 500 instead of a controlled failure. Gitea and Forgejo checked the status but not the body, and raised the identical `TypeError` on a non-JSON body (an HTML error page from a proxy decodes to a string).

Reading an error payload as a file list is the quieter half, and it does not crash:

| Adapter | Status checked | `{"message": "Bad credentials"}` at 200 | HTML error page at 200 |
|---|---|---|---|
| GitHub | no | returned the payload as the file list | **`TypeError`** |
| Gitea / Forgejo | yes | returned the payload as the file list | **`TypeError`** |
| GitLab | yes | returned `[{"filename": ""}]` | returned `[]` |
| Bitbucket | yes | `[]`, correctly — its pages *are* objects | returned `[]` |

Both consumers read `filename` / `previous_filename` off the result to decide which deployments a push affects, so a failed fetch that returns an empty list looks like a pull request that changed nothing, and the deployments are silently skipped. That failure mode reaches no error tracker at all.

## Fix

Check the status before the body on GitHub, and require a list of file records everywhere before merging one. Pagination is unchanged in every adapter.

Only GitHub is released today, which is why it is the only one reporting this — not the only one affected.

## Test plan

`Base` now drives these paths from canned responses, since a live forge cannot be made to page or fail on demand. Each adapter describes its own page shape through `pullRequestFilesPage()`; Gogs opts out through the `$supportsPullRequestLookup` flag it already sets, and Forgejo inherits Gitea's coverage.

Four tests per adapter — pagination across two pages, 401/403/404/500, a failure on a later page, and malformed bodies. Reverting `src/` alone fails 7 of them, across all five supported adapters, including both `array_merge()` TypeErrors. The pagination tests pass before and after, which is what shows paging is untouched.

`composer lint` and `composer check` are clean.

Note for review: these run through `setupAdapter()`, so they need the usual credentials or compose stack. I could not bring a forge up locally (Docker daemon unresponsive) and verified the harness with throwaway subclasses that stub `setupAdapter()`. CI is the first run through the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
