### PR TITLE
Report adapter capabilities and prove public repositories reach anonymous clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ VCS Adapters:
 | Adapter | Status |
 |---------|---------|
 | GitHub | ✅ |
-| GitLab |  |
-| Bitbucket |  |
+| GitLab | ✅ |
+| Bitbucket | ✅ |
 | Azure DevOps |  |
 
 `✅  - supported, 🛠  - work in progress`

--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -100,6 +100,56 @@ abstract class Git extends Adapter
     abstract public function createTag(string $owner, string $repositoryName, string $tagName, string $target, string $message = ''): array;
 
     /**
+     * Whether the provider lets this integration create repositories. Some
+     * partner APIs reserve creation for user principals.
+     */
+    public function supportsRepositoryCreation(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Whether the provider exposes an endpoint to delete a repository.
+     */
+    public function supportsRepositoryDeletion(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Whether the provider can hand out an archive download URL at all, so a
+     * consumer can arrange its own source packaging before calling
+     * getRepositoryPresignedUrl() just to catch it throwing.
+     */
+    public function supportsRepositoryArchives(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Whether images embedded in pull request comments can render on the
+     * provider. Providers without an image proxy (the way GitHub rewrites
+     * comment images through its camo CDN) cannot display images hosted on
+     * the consumer's own host - often private or plain-HTTP - so consumers
+     * should fall back to text there.
+     */
+    public function supportsCommentImages(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Whether the provider can host repositories that anonymous clients are
+     * able to read. Providers that scope every repository to an
+     * authenticated audience have no public repositories, whatever a
+     * visibility flag may claim.
+     */
+    public function supportsPublicRepositories(): bool
+    {
+        return true;
+    }
+
+    /**
      * Headers a caller must send with getRepositoryPresignedUrl() to reach a
      * private repository.
      *

--- a/tests/VCS/Adapter/BitbucketTest.php
+++ b/tests/VCS/Adapter/BitbucketTest.php
@@ -50,6 +50,11 @@ class BitbucketTest extends Base
         return 'sha256=' . hash_hmac('sha256', $payload, $secret);
     }
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return 'https://bitbucket.org/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     protected function setupAdapter(): void
     {
         if (empty(static::$accessToken)) {

--- a/tests/VCS/Adapter/ForgejoTest.php
+++ b/tests/VCS/Adapter/ForgejoTest.php
@@ -41,6 +41,11 @@ class ForgejoTest extends GiteaTest
         $this->vcsAdapter = $adapter;
     }
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return System::getEnv('TESTS_FORGEJO_URL', 'http://forgejo:3000') . '/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     protected function setupForgejo(): void
     {
         $tokenFile = '/forgejo-data/gitea/token.txt';

--- a/tests/VCS/Adapter/GitHubTest.php
+++ b/tests/VCS/Adapter/GitHubTest.php
@@ -33,6 +33,11 @@ class GitHubTest extends Base
     protected static string $eventHeader = 'x-github-event';
     protected static string $signatureHeader = 'x-hub-signature-256';
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return 'https://github.com/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     protected function setupAdapter(): void
     {
         $privateKey = str_replace('\\n', "\n", System::getEnv('TESTS_GITHUB_PRIVATE_KEY') ?? '');

--- a/tests/VCS/Adapter/GitLabTest.php
+++ b/tests/VCS/Adapter/GitLabTest.php
@@ -69,6 +69,11 @@ class GitLabTest extends Base
         $this->vcsAdapter = $adapter;
     }
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return System::getEnv('TESTS_GITLAB_URL', 'http://gitlab:80') . '/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     /**
      * GitLab owners are carried as "id:path", but it reports the path alone.
      */

--- a/tests/VCS/Adapter/GiteaTest.php
+++ b/tests/VCS/Adapter/GiteaTest.php
@@ -59,6 +59,11 @@ class GiteaTest extends Base
         $this->vcsAdapter = $adapter;
     }
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return System::getEnv('TESTS_GITEA_URL', 'http://gitea:3000') . '/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     protected function setupGitea(): void
     {
         $tokenFile = '/data/gitea/token.txt';

--- a/tests/VCS/Adapter/GogsTest.php
+++ b/tests/VCS/Adapter/GogsTest.php
@@ -48,6 +48,11 @@ class GogsTest extends GiteaTest
         $this->vcsAdapter = $adapter;
     }
 
+    protected function anonymousCloneUrl(string $repositoryName): string
+    {
+        return System::getEnv('TESTS_GOGS_URL', 'http://gogs:3000') . '/' . $this->ownerPath() . '/' . $repositoryName . '.git';
+    }
+
     protected function setupGogs(): void
     {
         $tokenFile = '/gogs-data/gogs/token.txt';

--- a/tests/VCS/Base.php
+++ b/tests/VCS/Base.php
@@ -204,6 +204,12 @@ abstract class Base extends TestCase
      */
     abstract protected function pullRequestPayload(bool $external = false): string;
 
+    /**
+     * URL an anonymous git client would clone the repository from over HTTP,
+     * with no credentials embedded.
+     */
+    abstract protected function anonymousCloneUrl(string $repositoryName): string;
+
     protected function setUp(): void
     {
         $this->setupAdapter();
@@ -473,6 +479,54 @@ abstract class Base extends TestCase
             $this->assertTrue($this->isPrivate($fetched), 'getRepository() did not report the new repository as private');
         } finally {
             $this->discardRepositories($repositoryName);
+        }
+    }
+
+    /**
+     * Response an anonymous git client gets for the repository: the ref
+     * advertisement request `git clone` opens with, sent without credentials.
+     *
+     * @return array{0: int, 1: string} Status code and body
+     */
+    private function fetchAnonymousRefAdvertisement(string $repositoryName): array
+    {
+        $client = new Client();
+        $response = $client->fetch(
+            url: $this->anonymousCloneUrl($repositoryName) . '/info/refs',
+            method: 'GET',
+            query: ['service' => 'git-upload-pack']
+        );
+
+        return [$response->getStatusCode(), $response->text()];
+    }
+
+    /**
+     * The visibility flag alone proves nothing about what reaches the
+     * outside; a public repository has to answer an anonymous git client.
+     * A private repository has to refuse the same request, or the public
+     * answer would say nothing beyond the server being up.
+     */
+    public function testPublicRepositoryIsPubliclyAccessible(): void
+    {
+        $this->skipUnlessSupported($this->vcsAdapter->supportsPublicRepositories(), 'public repositories');
+
+        $publicRepository = 'test-public-access-' . \uniqid();
+        $privateRepository = 'test-private-access-' . \uniqid();
+
+        $this->vcsAdapter->createRepository(static::$owner, $publicRepository, false);
+        $this->vcsAdapter->createRepository(static::$owner, $privateRepository, true);
+
+        try {
+            $this->assertEventually(function () use ($publicRepository) {
+                [$status, $body] = $this->fetchAnonymousRefAdvertisement($publicRepository);
+                $this->assertSame(200, $status, 'An anonymous git client cannot reach the public repository');
+                $this->assertStringContainsString('git-upload-pack', $body, 'The anonymous response is not a git ref advertisement');
+            });
+
+            [$status] = $this->fetchAnonymousRefAdvertisement($privateRepository);
+            $this->assertNotSame(200, $status, 'An anonymous git client can read the private repository');
+        } finally {
+            $this->discardRepositories($publicRepository, $privateRepository);
         }
     }
 


### PR DESCRIPTION
## What

- Adds capability methods to the `Git` adapter so consumers can ask what a provider supports instead of calling into a missing endpoint just to catch it throwing:
  - `supportsRepositoryCreation()`
  - `supportsRepositoryDeletion()`
  - `supportsRepositoryArchives()`
  - `supportsCommentImages()`
  - `supportsPublicRepositories()`

  All default to `true`; providers that lack a capability override the method.

- Adds `testPublicRepositoryIsPubliclyAccessible` to the shared suite. Existing tests only asserted the `private` flag the provider *reports*; this one proves publicness end to end by sending the git smart-HTTP ref advertisement request (`GET …/info/refs?service=git-upload-pack`, the request `git clone` opens with) **without credentials**. A public repository has to answer 200 with a real `git-upload-pack` advertisement, and a private one has to refuse the same request — otherwise the public answer would say nothing beyond the server being up. Each adapter test supplies its anonymous clone URL via a new abstract `anonymousCloneUrl()`.

- Marks GitLab and Bitbucket as supported in the README's adapter table.

## Verification

- `composer lint` and `composer check` (PHPStan level 8) pass.
- Full Gitea suite green against the Docker stack: 103 tests, 371 assertions (12 capability skips), including the new public-access test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)