### PR TITLE
feat: expose the repository clone URL and its auth headers

### DIFF
--- a/src/VCS/Adapter/Git.php
+++ b/src/VCS/Adapter/Git.php
@@ -127,6 +127,28 @@ abstract class Git extends Adapter
     }
 
     /**
+     * Git HTTPS URL of a repository, for a consumer that clones instead of
+     * downloading an archive. Carries no credentials - they ride the headers
+     * from getRepositoryCloneHeaders(), never a string that errors and logs
+     * echo verbatim.
+     */
+    public function getRepositoryCloneUrl(string $owner, string $repositoryName): string
+    {
+        throw new Exception('getRepositoryCloneUrl() is not supported by ' . $this->getName());
+    }
+
+    /**
+     * Headers authenticating a fetch of getRepositoryCloneUrl(), typically
+     * Authorization. Empty when the repository needs none.
+     *
+     * @return array<string, string>
+     */
+    public function getRepositoryCloneHeaders(): array
+    {
+        return [];
+    }
+
+    /**
      * Whether images embedded in pull request comments can render on the
      * provider. Providers without an image proxy (the way GitHub rewrites
      * comment images through its camo CDN) cannot display images hosted on

--- a/src/VCS/Adapter/Git/Origin.php
+++ b/src/VCS/Adapter/Git/Origin.php
@@ -1707,6 +1707,31 @@ class Origin extends Git
     }
 
     /**
+     * Git HTTPS URL of a repository. Origin serves content over Git HTTPS
+     * only, so this is the URL consumers clone instead of downloading an
+     * archive.
+     */
+    public function getRepositoryCloneUrl(string $owner, string $repositoryName): string
+    {
+        return $this->gitEndpoint . '/' . \urlencode($owner) . '/' . \urlencode($repositoryName) . '.git';
+    }
+
+    /**
+     * Origin's Git endpoint takes HTTP Basic credentials with the fixed
+     * username x-access-token and the installation token as the password.
+     *
+     * @return array<string, string>
+     */
+    public function getRepositoryCloneHeaders(): array
+    {
+        if (empty($this->accessToken)) {
+            return [];
+        }
+
+        return ['Authorization' => 'Basic ' . \base64_encode('x-access-token:' . $this->accessToken)];
+    }
+
+    /**
      * Origin renders comment markdown without proxying images, so images on
      * a consumer's own host cannot display; comments should stay textual.
      */


### PR DESCRIPTION
## What does this PR do?

A provider without archive downloads reports `supportsRepositoryArchives() === false`, but the library gave consumers nothing to clone with — the authenticated URL existed only inside `generateCloneCommand()`, as an embedded-credential string in a shell command.

This adds two methods next to the capability:

- `getRepositoryCloneUrl($owner, $repositoryName)` — the Git HTTPS URL, **without credentials**. Base `Git` throws (mirroring `getRepositoryPresignedUrl()`); Origin overrides.
- `getRepositoryCloneHeaders()` — the headers that authenticate a fetch of that URL (Origin: `Authorization: Basic x-access-token:<installation token>`), empty when none are needed.

Credentials ride a header rather than URL userinfo so tokens never surface in the errors and logs that echo URLs verbatim.

First consumer: Appwrite's deployment pipeline hands these to the orchestrator's new `clone` artifact for providers that serve content over Git HTTPS only (Origin).

## Test Plan

- Pint and PHPStan (level 8, src + tests) pass.
- Origin integration suite remains skipped upstream (fixtures cannot be provisioned automatically); the override mirrors `authenticatedCloneUrl()`, which the skipped suite covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)